### PR TITLE
Also apply google java format to imports #2

### DIFF
--- a/src/main/java/com/nikodoko/javaimports/cli/CLI.java
+++ b/src/main/java/com/nikodoko/javaimports/cli/CLI.java
@@ -68,7 +68,7 @@ public final class CLI {
 
   private String googleFormat(String code) {
     try {
-      return new Formatter().formatSource(code);
+      return new Formatter().formatSourceAndFixImports(code);
     } catch (FormatterException e) {
       // Formatting is not vital, so print a warning and continue
       errWriter.println("WARNING: formatter exception: " + e);


### PR DESCRIPTION
Javaimports currently cannot remove unused imports (as it
does not handle javadoc properly). As a temporary solution, rely on
GJF's built in RemoveUnusedImports to do it.

See #2 