### PR TITLE
Improve ImporterDiagnostic's string representation

### DIFF
--- a/src/main/java/com/nikodoko/javaimports/Importer.java
+++ b/src/main/java/com/nikodoko/javaimports/Importer.java
@@ -16,6 +16,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -74,7 +76,7 @@ public final class Importer {
    */
   public String addUsedImports(final Path filename, final String javaCode)
       throws ImporterException {
-    ParsedFile f = parser.parse(javaCode);
+    ParsedFile f = parser.parse(filename, javaCode);
 
     Fixer fixer = Fixer.init(f, fixerOptions(options));
     // Initial run with the current file only.
@@ -103,7 +105,7 @@ public final class Importer {
 
   // Find and parse all java files in the directory of filename, excepting filename itself
   private Set<ParsedFile> parseSiblings(final Path filename) throws ImporterException {
-    List<String> sources = new ArrayList<>();
+    Map<Path, String> sources = new HashMap<>();
     try {
       // Retrieve all java files in the parent directory of filename, excluding filename and not
       // searching recursively
@@ -117,7 +119,7 @@ public final class Importer {
               .collect(Collectors.toList());
 
       for (Path p : paths) {
-        sources.add(new String(Files.readAllBytes(p), UTF_8));
+        sources.put(p, new String(Files.readAllBytes(p), UTF_8));
       }
     } catch (IOException e) {
       throw new IOError(e);
@@ -127,8 +129,8 @@ public final class Importer {
     // XXX: might want to run the parsing on all files, and combine the exceptions instead of
     // stopping at the first incorrect file. That way the user knows all the errors and can fix all
     // of them without rerunning the tool.
-    for (String source : sources) {
-      siblings.add(parser.parse(source));
+    for (Map.Entry<Path, String> source : sources.entrySet()) {
+      siblings.add(parser.parse(source.getKey(), source.getValue()));
     }
 
     return siblings;

--- a/src/main/java/com/nikodoko/javaimports/ImporterException.java
+++ b/src/main/java/com/nikodoko/javaimports/ImporterException.java
@@ -26,6 +26,20 @@ public class ImporterException extends Exception {
     return new ImporterException(importerDiagnostics);
   }
 
+  /**
+   * Combine multiple exceptions into a new one
+   *
+   * @param exceptions a list of {@code ImporterException} to combine
+   */
+  public static ImporterException combine(List<ImporterException> exceptions) {
+    List<ImporterDiagnostic> combined = new ArrayList<>();
+    for (ImporterException e : exceptions) {
+      combined.addAll(e.diagnostics());
+    }
+
+    return new ImporterException(combined);
+  }
+
   private ImporterException(List<ImporterDiagnostic> diagnostics) {
     this.diagnostics = diagnostics;
   }

--- a/src/main/java/com/nikodoko/javaimports/ImporterException.java
+++ b/src/main/java/com/nikodoko/javaimports/ImporterException.java
@@ -2,7 +2,6 @@ package com.nikodoko.javaimports;
 
 import static java.util.Locale.ENGLISH;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.openjdk.javax.tools.Diagnostic;
@@ -18,7 +17,7 @@ public class ImporterException extends Exception {
    * @param diagnostics a list of parser diagnostics
    */
   public static ImporterException fromDiagnostics(
-      Path filename, List<Diagnostic<? extends JavaFileObject>> diagnostics) {
+      String filename, List<Diagnostic<? extends JavaFileObject>> diagnostics) {
     List<ImporterDiagnostic> importerDiagnostics = new ArrayList<>();
     for (Diagnostic<?> d : diagnostics) {
       importerDiagnostics.add(ImporterDiagnostic.create(filename, d));
@@ -45,19 +44,19 @@ public class ImporterException extends Exception {
     private final int line;
     private final int column;
     private final String message;
-    private final Path filename;
+    private final String filename;
 
     /**
      * Wrap a parser diagnostic
      *
      * @param d the diagnostic to wrap
      */
-    public static ImporterDiagnostic create(Path filename, Diagnostic<?> d) {
+    public static ImporterDiagnostic create(String filename, Diagnostic<?> d) {
       return new ImporterDiagnostic(
           filename, (int) d.getLineNumber(), (int) d.getColumnNumber(), d.getMessage(ENGLISH));
     }
 
-    private ImporterDiagnostic(Path filename, int line, int column, String message) {
+    private ImporterDiagnostic(String filename, int line, int column, String message) {
       // TODO: assert > 0 with precondition
       this.filename = filename;
       this.line = line;
@@ -66,7 +65,7 @@ public class ImporterException extends Exception {
     }
 
     public String toString() {
-      return filename + ": " + line + ":" + column + ": error: " + message;
+      return filename + ":" + line + ":" + column + ": error: " + message;
     }
   }
 }

--- a/src/main/java/com/nikodoko/javaimports/parser/Parser.java
+++ b/src/main/java/com/nikodoko/javaimports/parser/Parser.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.logging.Logger;
+import java.nio.file.Path;
 import java.util.stream.Collectors;
 import org.openjdk.javax.tools.Diagnostic;
 import org.openjdk.javax.tools.DiagnosticCollector;
@@ -48,9 +49,9 @@ public class Parser {
    * @param javaCode the input code
    * @throws ImporterException if the input cannot be parsed
    */
-  public ParsedFile parse(final String javaCode) throws ImporterException {
+  public ParsedFile parse(final Path filename, final String javaCode) throws ImporterException {
     // Parse the code into a compilation unit containing the AST
-    JCCompilationUnit unit = getCompilationUnit(javaCode);
+    JCCompilationUnit unit = getCompilationUnit(filename, javaCode);
 
     // Scan the AST
     UnresolvedIdentifierScanner scanner = new UnresolvedIdentifierScanner();
@@ -72,7 +73,8 @@ public class Parser {
   }
 
   @VisibleForTesting
-  static JCCompilationUnit getCompilationUnit(final String javaCode) throws ImporterException {
+  static JCCompilationUnit getCompilationUnit(final Path filename, final String javaCode)
+      throws ImporterException {
     Context ctx = new Context();
     DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
     ctx.put(DiagnosticListener.class, diagnostics);
@@ -109,7 +111,7 @@ public class Parser {
             .collect(Collectors.toList());
 
     if (!errorDiagnostics.isEmpty()) {
-      throw ImporterException.fromDiagnostics(errorDiagnostics);
+      throw ImporterException.fromDiagnostics(filename, errorDiagnostics);
     }
 
     return unit;

--- a/src/main/java/com/nikodoko/javaimports/parser/Parser.java
+++ b/src/main/java/com/nikodoko/javaimports/parser/Parser.java
@@ -8,9 +8,9 @@ import com.nikodoko.javaimports.ImporterException;
 import java.io.IOError;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Logger;
-import java.nio.file.Path;
 import java.util.stream.Collectors;
 import org.openjdk.javax.tools.Diagnostic;
 import org.openjdk.javax.tools.DiagnosticCollector;
@@ -51,7 +51,7 @@ public class Parser {
    */
   public ParsedFile parse(final Path filename, final String javaCode) throws ImporterException {
     // Parse the code into a compilation unit containing the AST
-    JCCompilationUnit unit = getCompilationUnit(filename, javaCode);
+    JCCompilationUnit unit = getCompilationUnit(filename.toString(), javaCode);
 
     // Scan the AST
     UnresolvedIdentifierScanner scanner = new UnresolvedIdentifierScanner();
@@ -73,7 +73,7 @@ public class Parser {
   }
 
   @VisibleForTesting
-  static JCCompilationUnit getCompilationUnit(final Path filename, final String javaCode)
+  static JCCompilationUnit getCompilationUnit(final String filename, final String javaCode)
       throws ImporterException {
     Context ctx = new Context();
     DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();

--- a/src/test/java/com/nikodoko/javaimports/parser/UnresolvedIdentifierScannerTest.java
+++ b/src/test/java/com/nikodoko/javaimports/parser/UnresolvedIdentifierScannerTest.java
@@ -943,7 +943,7 @@ public class UnresolvedIdentifierScannerTest {
   public void scanTest() throws Exception {
     UnresolvedIdentifierScanner scanner = new UnresolvedIdentifierScanner();
     try {
-      scanner.scan(Parser.getCompilationUnit(input), null);
+      scanner.scan(Parser.getCompilationUnit("testfile", input), null);
     } catch (ImporterException e) {
       for (ImporterException.ImporterDiagnostic d : e.diagnostics()) {
         System.out.println(d);


### PR DESCRIPTION
* Make sure it includes the file name and is natively compatible with VIM (Fix #8 )
* When parsing siblings, parse all of them even if one is wrong, and combine all the diagnostics (avoid the "running once, fix errors, run twice, fix errors..." if many package files are wrong)