### PR TITLE
Specify encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   </scm>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.version>4.12</junit.version>
     <java.version>1.8</java.version>
     <javac.version>9+181-r4173-1</javac.version>


### PR DESCRIPTION
Remove this warning when building
```
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```