### PR TITLE
Fix candidate priority

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/Importer.java
+++ b/core/src/main/java/com/nikodoko/javaimports/Importer.java
@@ -10,7 +10,6 @@ import com.nikodoko.javaimports.fixer.Result;
 import com.nikodoko.javaimports.parser.Import;
 import com.nikodoko.javaimports.parser.ParsedFile;
 import com.nikodoko.javaimports.parser.Parser;
-import com.nikodoko.javaimports.stdlib.StdlibProviders;
 import java.io.IOError;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -98,7 +97,7 @@ public final class Importer {
     // If other files in the package contain identifiers that also are in the standard library, we
     // want to resolve them before so as to avoid adding uneeded imports, so we need to add both the
     // stdlib provider and the resolver at the same time.
-    fixer.addStdlibProvider(StdlibProviders.java8());
+    fixer.addStdlibProvider(options.stdlib());
     fixer.addEnvironment(Environments.autoSelect(filename, f.packageName(), options));
 
     return applyFixes(f, javaCode, fixer.lastTryToFix());

--- a/core/src/main/java/com/nikodoko/javaimports/Options.java
+++ b/core/src/main/java/com/nikodoko/javaimports/Options.java
@@ -1,5 +1,7 @@
 package com.nikodoko.javaimports;
 
+import com.nikodoko.javaimports.stdlib.StdlibProvider;
+import com.nikodoko.javaimports.stdlib.StdlibProviders;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -7,25 +9,33 @@ import java.util.Optional;
 public class Options {
   boolean debug;
   Optional<Path> repository;
+  StdlibProvider stdlib;
 
-  public Options(boolean debug, Optional<Path> repository) {
+  public Options(boolean debug, Optional<Path> repository, StdlibProvider stdlib) {
     this.debug = debug;
     this.repository = repository;
+    this.stdlib = stdlib;
   }
 
-  /** Specific directory to use as a dependency repository */
+  /** Specific directory to use as a dependency repository. */
   public Optional<Path> repository() {
     return repository;
   }
 
-  /** Whether to run the {@code Importer} in debug mode */
+  /** Whether to run the {@code Importer} in debug mode. */
   public boolean debug() {
     return debug;
+  }
+
+  /** The standard library to use for this run. */
+  public StdlibProvider stdlib() {
+    return stdlib;
   }
 
   public static class Builder {
     boolean debug;
     Path repository;
+    StdlibProvider stdlib;
 
     public Builder() {}
 
@@ -39,8 +49,13 @@ public class Options {
       return this;
     }
 
+    public Builder stdlib(StdlibProvider stdlib) {
+      this.stdlib = stdlib;
+      return this;
+    }
+
     public Options build() {
-      return new Options(debug, Optional.ofNullable(repository));
+      return new Options(debug, Optional.ofNullable(repository), stdlib);
     }
   }
 
@@ -50,6 +65,6 @@ public class Options {
 
   /** Default options */
   public static Options defaults() {
-    return builder().debug(false).build();
+    return builder().debug(false).stdlib(StdlibProviders.empty()).build();
   }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/cli/CLI.java
+++ b/core/src/main/java/com/nikodoko/javaimports/cli/CLI.java
@@ -7,6 +7,7 @@ import com.google.googlejavaformat.java.FormatterException;
 import com.nikodoko.javaimports.Importer;
 import com.nikodoko.javaimports.ImporterException;
 import com.nikodoko.javaimports.Options;
+import com.nikodoko.javaimports.stdlib.StdlibProviders;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -102,7 +103,9 @@ public final class CLI {
       return 1;
     }
 
-    Options opts = Options.builder().debug(params.verbose()).build();
+    // TODO: make stdlib version a CLI option
+    Options opts =
+        Options.builder().debug(params.verbose()).stdlib(StdlibProviders.java8()).build();
     String fixed;
     try {
       fixed = new Importer(opts).addUsedImports(path, input);

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/Fixer.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/Fixer.java
@@ -9,7 +9,7 @@ import com.nikodoko.javaimports.parser.Import;
 import com.nikodoko.javaimports.parser.ParsedFile;
 import com.nikodoko.javaimports.stdlib.StdlibProvider;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -87,11 +87,10 @@ public class Fixer {
     boolean allGood = true;
     Set<Import> fixes = new HashSet<>();
     LoadResult loaded = loader.result();
-    Map<String, Import> candidates = loader.candidates();
     for (String ident : loaded.unresolved) {
-      Import fix = candidates.get(ident);
-      if (fix != null) {
-        fixes.add(fix);
+      Optional<Import> maybeFix = loaded.candidates.get(ident);
+      if (maybeFix.isPresent()) {
+        fixes.add(maybeFix.get());
         continue;
       }
 
@@ -112,8 +111,9 @@ public class Fixer {
     // resolved orphan classes
     for (ClassExtender orphan : loaded.orphans) {
       for (String ident : orphan.notYetResolved()) {
-        if (candidates.get(ident) != null) {
-          fixes.add(candidates.get(ident));
+        Optional<Import> maybeFix = loaded.candidates.get(ident);
+        if (maybeFix.isPresent()) {
+          fixes.add(maybeFix.get());
         }
       }
     }

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/internal/Candidates.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/internal/Candidates.java
@@ -1,0 +1,40 @@
+package com.nikodoko.javaimports.fixer.internal;
+
+import com.nikodoko.javaimports.parser.Import;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class Candidates {
+  private static class Candidate {
+    int priority;
+    Import i;
+  }
+
+  private Map<String, Candidate> candidates = new HashMap<>();
+
+  public void add(int priority, Iterable<Import> imports) {
+    for (Import i : imports) {
+      add(priority, i);
+    }
+  }
+
+  public void add(int priority, Import i) {
+    Candidate current = candidates.get(i.name());
+    if (current == null || current.priority < priority) {
+      Candidate better = new Candidate();
+      better.i = i;
+      better.priority = priority;
+      candidates.put(i.name(), better);
+    }
+  }
+
+  public Optional<Import> get(String identifier) {
+    Candidate candidate = candidates.get(identifier);
+    if (candidate == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(candidate.i);
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/internal/LoadResult.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/internal/LoadResult.java
@@ -8,6 +8,7 @@ import java.util.Set;
 public class LoadResult {
   public Set<String> unresolved;
   public Set<ClassExtender> orphans;
+  public Candidates candidates = new Candidates();
 
   public boolean isEmpty() {
     return unresolved.isEmpty() && orphans.isEmpty();

--- a/core/src/test/java/com/nikodoko/javaimports/ImporterIntegrationTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/ImporterIntegrationTest.java
@@ -139,7 +139,8 @@ public class ImporterIntegrationTest {
               .stdlib(
                   FakeStdlibProvider.of(
                       new Import("List", "java.util", false),
-                      new Import("ArrayList", "java.util", false)))
+                      new Import("ArrayList", "java.util", false),
+                      new Import("App", "java.fakeutil", false)))
               .build();
       String output = new Importer(opts).addUsedImports(main, input);
       assertWithMessage("bad output for " + module.name()).that(output).isEqualTo(expected);

--- a/core/src/test/java/com/nikodoko/javaimports/ImporterIntegrationTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/ImporterIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.fail;
 import com.google.common.io.CharStreams;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ResourceInfo;
+import com.nikodoko.javaimports.stdlib.StdlibProviders;
 import com.nikodoko.packagetest.BuildSystem;
 import com.nikodoko.packagetest.Export;
 import com.nikodoko.packagetest.Exported;
@@ -133,7 +134,11 @@ public class ImporterIntegrationTest {
     try {
       String input = new String(Files.readAllBytes(main), UTF_8);
       Options opts =
-          Options.builder().debug(false).repository(Paths.get(repositoryURL.toURI())).build();
+          Options.builder()
+              .debug(false)
+              .repository(Paths.get(repositoryURL.toURI()))
+              .stdlib(StdlibProviders.java8())
+              .build();
       String output = new Importer(opts).addUsedImports(main, input);
       assertWithMessage("bad output for " + module.name()).that(output).isEqualTo(expected);
     } catch (ImporterException e) {

--- a/core/src/test/java/com/nikodoko/javaimports/fixer/internal/CandidatesTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/fixer/internal/CandidatesTest.java
@@ -1,0 +1,32 @@
+package com.nikodoko.javaimports.fixer.internal;
+
+import static com.google.common.truth.Truth8.assertThat;
+
+import com.nikodoko.javaimports.parser.Import;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CandidatesTest {
+  Candidates candidates;
+
+  @BeforeEach
+  void setup() {
+    candidates = new Candidates();
+  }
+
+  @Test
+  void testHigherPriorityOverwritesLower() {
+    candidates.add(1, new Import("List", "java.util", false));
+    candidates.add(2, new Import("List", "a.dependency", false));
+
+    assertThat(candidates.get("List")).hasValue(new Import("List", "a.dependency", false));
+  }
+
+  @Test
+  void testLowerPriorityDoesNotOverwriteHigher() {
+    candidates.add(2, new Import("List", "a.dependency", false));
+    candidates.add(1, new Import("List", "java.util", false));
+
+    assertThat(candidates.get("List")).hasValue(new Import("List", "a.dependency", false));
+  }
+}

--- a/core/src/test/java/com/nikodoko/javaimports/stdlib/FakeStdlibProvider.java
+++ b/core/src/test/java/com/nikodoko/javaimports/stdlib/FakeStdlibProvider.java
@@ -1,0 +1,39 @@
+package com.nikodoko.javaimports.stdlib;
+
+import com.nikodoko.javaimports.parser.Import;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FakeStdlibProvider implements StdlibProvider {
+  Map<String, Import> imports = new HashMap<>();
+
+  public static FakeStdlibProvider of(Import... imports) {
+    Map<String, Import> byIdentifier = new HashMap<>();
+    for (Import i : imports) {
+      byIdentifier.put(i.name(), i);
+    }
+
+    return new FakeStdlibProvider(byIdentifier);
+  }
+
+  private FakeStdlibProvider(Map<String, Import> imports) {
+    this.imports = imports;
+  }
+
+  @Override
+  public Map<String, Import> find(Iterable<String> identifiers) {
+    Map<String, Import> found = new HashMap<>();
+    for (String id : identifiers) {
+      if (imports.containsKey(id)) {
+        found.put(id, imports.get(id));
+      }
+    }
+
+    return found;
+  }
+
+  @Override
+  public boolean isInJavaLang(String identifier) {
+    return false;
+  }
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeSiblingImportsOverStdlib/Other
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeSiblingImportsOverStdlib/Other
@@ -1,0 +1,7 @@
+package priorizeSiblingImportsOverStdlib;
+
+import a.custom.List;
+
+class Other {
+  List l;
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeSiblingImportsOverStdlib/priorizeSiblingImportsOverStdlib.input
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeSiblingImportsOverStdlib/priorizeSiblingImportsOverStdlib.input
@@ -1,0 +1,6 @@
+// Test that sibling imports are given priority over the stdlib
+package priorizeSiblingImportsOverStdlib;
+
+class Test {
+  List<String> list;
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeSiblingImportsOverStdlib/priorizeSiblingImportsOverStdlib.output
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeSiblingImportsOverStdlib/priorizeSiblingImportsOverStdlib.output
@@ -1,0 +1,6 @@
+// Test that sibling imports are given priority over the stdlib
+package priorizeSiblingImportsOverStdlib;import a.custom.List;
+
+class Test {
+  List<String> list;
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeStdlibOverExternal/priorizeStdlibOverExternal.input
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeStdlibOverExternal/priorizeStdlibOverExternal.input
@@ -1,0 +1,6 @@
+// Test that stdlib is chosen in priority over external import with the same name
+package prioritizeStdlibOverExternal;
+
+class Test {
+  App app;
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeStdlibOverExternal/priorizeStdlibOverExternal.output
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/priorizeStdlibOverExternal/priorizeStdlibOverExternal.output
@@ -1,0 +1,6 @@
+// Test that stdlib is chosen in priority over external import with the same name
+package prioritizeStdlibOverExternal;import java.fakeutil.App;
+
+class Test {
+  App app;
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/withexternaldependency/withexternaldependency.input
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/withexternaldependency/withexternaldependency.input
@@ -2,5 +2,5 @@
 package withexternaldependency;
 
 class Test {
-  App app;
+  Subclass app;
 }

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/withexternaldependency/withexternaldependency.output
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/withexternaldependency/withexternaldependency.output
@@ -1,6 +1,6 @@
 // Test that external dependencies are resolved
-package withexternaldependency;import com.mycompany.app.App;
+package withexternaldependency;import com.mycompany.app.App.Subclass;
 
 class Test {
-  App app;
+  Subclass app;
 }


### PR DESCRIPTION
* Make sure stdlib imports have priority over external dependencies, but not over imports from other files in the package.

Fix #26 