### PR TITLE
Fix class hierarchy

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/fixer/internal/Loader.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/internal/Loader.java
@@ -174,8 +174,10 @@ public class Loader {
   }
 
   private void extendUsingSiblings(ClassExtender toExtend) {
-    ClassHierarchy[] hierarchies = new ClassHierarchy[siblings.size()];
-    int i = 0;
+    ClassHierarchy[] hierarchies = new ClassHierarchy[siblings.size() + 1];
+    // Some siblings' classes might depend on classes defined in the file to fix
+    hierarchies[0] = file.classHierarchy();
+    int i = 1;
     for (ParsedFile sibling : siblings) {
       hierarchies[i++] = sibling.classHierarchy();
     }

--- a/core/src/main/java/com/nikodoko/javaimports/parser/ClassHierarchies.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/ClassHierarchies.java
@@ -2,7 +2,10 @@ package com.nikodoko.javaimports.parser;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.collect.TreeTraverser;
+import com.nikodoko.javaimports.parser.internal.ClassEntity;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /** Utility methods for {@link ClassHierarchy}. */
 public class ClassHierarchies {
@@ -30,5 +33,13 @@ public class ClassHierarchies {
     }
 
     return root;
+  }
+
+  public static Stream<ClassEntity> flatView(ClassHierarchy root) {
+    return TreeTraverser.using(ClassHierarchy::childs).preOrderTraversal(root).stream()
+        .map(ClassHierarchy::entity)
+        // Skip one because the root is not a proper class
+        // TODO: should we change that?
+        .skip(1);
   }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/parser/ClassHierarchy.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/ClassHierarchy.java
@@ -40,6 +40,17 @@ public class ClassHierarchy {
     return new ClassHierarchy(parent, ClassEntity.NOT_A_CLASS);
   }
 
+  // NEW METHODS
+  Iterable<ClassHierarchy> childs() {
+    return childs.values();
+  }
+
+  ClassEntity entity() {
+    return entity;
+  }
+
+  // END NEW METHODS
+
   /**
    * Adds {@code childEntity} to the list of childs of this {@code ClassHierarchy}, and moves to
    * this new child node.

--- a/core/src/main/java/com/nikodoko/javaimports/parser/ClassHierarchy.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/ClassHierarchy.java
@@ -8,8 +8,7 @@ import com.nikodoko.javaimports.parser.internal.ClassSelector;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 /**
@@ -22,14 +21,15 @@ import java.util.Optional;
 public class ClassHierarchy {
   ClassHierarchy parent;
   ClassEntity entity;
-  Map<String, ClassHierarchy> childs;
+  // We want values to be presented in order of insertion
+  LinkedHashMap<String, ClassHierarchy> childs;
 
   private ClassHierarchy(ClassHierarchy parent, ClassEntity entity) {
     checkNotNull(entity);
 
     this.entity = entity;
     this.parent = parent;
-    this.childs = new HashMap<>();
+    this.childs = new LinkedHashMap<>();
   }
 
   static ClassHierarchy root() {
@@ -41,6 +41,7 @@ public class ClassHierarchy {
   }
 
   // NEW METHODS
+  /** This is guaranteed to return classes in the order they were declared. */
   Iterable<ClassHierarchy> childs() {
     return childs.values();
   }

--- a/core/src/main/java/com/nikodoko/javaimports/parser/ParsedFile.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/ParsedFile.java
@@ -2,12 +2,14 @@ package com.nikodoko.javaimports.parser;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Range;
+import com.nikodoko.javaimports.parser.internal.ClassEntity;
 import com.nikodoko.javaimports.parser.internal.Scope;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.openjdk.tools.javac.tree.JCTree.JCCompilationUnit;
 import org.openjdk.tools.javac.tree.JCTree.JCExpression;
 import org.openjdk.tools.javac.tree.JCTree.JCImport;
@@ -113,7 +115,7 @@ public class ParsedFile {
     return this;
   }
 
-  public ParsedFile classHierarchy(ClassHierarchy topClass) {
+  public ParsedFile classHierarchy(ClassHierarchy classHierarchy) {
     this.classHierarchy = classHierarchy;
     return this;
   }
@@ -132,6 +134,10 @@ public class ParsedFile {
 
   public ClassHierarchy classHierarchy() {
     return classHierarchy;
+  }
+
+  public Stream<ClassEntity> classes() {
+    return ClassHierarchies.flatView(classHierarchy);
   }
 
   /** Debugging support. */

--- a/core/src/main/java/com/nikodoko/javaimports/parser/internal/ClassEntity.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/internal/ClassEntity.java
@@ -2,6 +2,7 @@ package com.nikodoko.javaimports.parser.internal;
 
 import com.google.common.base.MoreObjects;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -58,5 +59,26 @@ public class ClassEntity {
         .add("members", members)
         .add("superclass", superclass)
         .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (!(o instanceof ClassEntity)) {
+      return false;
+    }
+
+    ClassEntity that = (ClassEntity) o;
+    return Objects.equals(this.name, that.name)
+        && Objects.equals(this.members, that.members)
+        && Objects.equals(this.superclass, that.superclass);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.name, this.members, this.superclass);
   }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/parser/internal/ClassSelectors.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/internal/ClassSelectors.java
@@ -1,5 +1,6 @@
 package com.nikodoko.javaimports.parser.internal;
 
+import java.util.Objects;
 import java.util.Optional;
 import org.openjdk.tools.javac.tree.JCTree.JCExpression;
 import org.openjdk.tools.javac.tree.JCTree.JCFieldAccess;
@@ -80,6 +81,25 @@ public class ClassSelectors {
     @Override
     public Optional<ClassSelector> next() {
       return Optional.ofNullable(next);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(this.selector, this.next);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null) {
+        return false;
+      }
+
+      if (!(o instanceof Selector)) {
+        return false;
+      }
+
+      Selector that = (Selector) o;
+      return Objects.equals(this.selector, that.selector) && Objects.equals(this.next, that.next);
     }
 
     @Override

--- a/core/src/test/java/com/nikodoko/javaimports/parser/ClassHierarchiesTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/parser/ClassHierarchiesTest.java
@@ -12,6 +12,7 @@ public class ClassHierarchiesTest {
   static ClassHierarchy leaf;
   static ClassEntity A = ClassEntity.named("A");
   static ClassEntity B = ClassEntity.named("B");
+  static ClassEntity C = ClassEntity.named("C");
   static ClassEntity C1 = ClassEntity.named("C1");
   static ClassEntity C2 = ClassEntity.named("C2");
 
@@ -19,8 +20,10 @@ public class ClassHierarchiesTest {
   // root
   // |
   // - A
-  //   |
-  //   - B
+  // | |
+  // | - B
+  // |
+  // - C
   //
   // leaf
   // |
@@ -28,11 +31,13 @@ public class ClassHierarchiesTest {
   // - C2
   @BeforeAll
   static void setupHierarchy() {
-    root = ClassHierarchies.root();
-
-    ClassHierarchy hierarchy = root;
+    ClassHierarchy hierarchy = ClassHierarchies.root();
+    root = hierarchy;
     hierarchy = hierarchy.moveTo(A);
     hierarchy = hierarchy.moveTo(B);
+    hierarchy = hierarchy.moveUp().get();
+    hierarchy = hierarchy.moveUp().get();
+    hierarchy = hierarchy.moveTo(C);
     hierarchy = hierarchy.moveToLeaf();
     leaf = hierarchy;
     hierarchy = hierarchy.moveTo(C1);
@@ -44,6 +49,7 @@ public class ClassHierarchiesTest {
   void testFound() {
     assertThat(root.find(ClassSelectors.of("A"))).hasValue(A);
     assertThat(root.find(ClassSelectors.of("A", "B"))).hasValue(B);
+    assertThat(root.find(ClassSelectors.of("C"))).hasValue(C);
   }
 
   @Test
@@ -53,8 +59,8 @@ public class ClassHierarchiesTest {
 
   @Test
   void testLeafNotReachableFromParent() {
-    assertThat(root.find(ClassSelectors.of("A", "B", "C1"))).isEmpty();
-    assertThat(root.find(ClassSelectors.of("A", "B", "C2"))).isEmpty();
+    assertThat(root.find(ClassSelectors.of("C", "C1"))).isEmpty();
+    assertThat(root.find(ClassSelectors.of("C", "C2"))).isEmpty();
   }
 
   @Test
@@ -71,5 +77,10 @@ public class ClassHierarchiesTest {
     assertThat(leaf.find(ClassSelectors.of("C2"))).hasValue(C2);
     assertThat(root.find(ClassSelectors.of("A"))).hasValue(A);
     assertThat(root.find(ClassSelectors.of("A", "B"))).hasValue(B);
+  }
+
+  @Test
+  void testFlatView() {
+    assertThat(ClassHierarchies.flatView(root)).containsExactly(A, B, C).inOrder();
   }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/parser/ParserTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/parser/ParserTest.java
@@ -4,10 +4,12 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.nikodoko.javaimports.ImporterException;
 import com.nikodoko.javaimports.Options;
 import com.nikodoko.javaimports.parser.internal.ClassEntity;
+import com.nikodoko.javaimports.parser.internal.ClassSelectors;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Set;
@@ -33,7 +35,7 @@ public class ParserTest {
         "}",
       },
       {"b"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("g", "f"))},
     },
     {
       {"forLoop"},
@@ -55,7 +57,7 @@ public class ParserTest {
         "}",
       },
       {"staticFunction", "i", "b", "e", "d"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"ifBlock"},
@@ -74,7 +76,7 @@ public class ParserTest {
         "}",
       },
       {"a", "b", "c"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"whileLoop"},
@@ -90,7 +92,7 @@ public class ParserTest {
         "}",
       },
       {"a"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"synchronizedBlock"},
@@ -107,7 +109,7 @@ public class ParserTest {
       },
       // The parser does not know about "this" and sees it as an unresolved symbol
       {"this", "a"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"doWhileLoop"},
@@ -123,7 +125,7 @@ public class ParserTest {
         "}",
       },
       {"a"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"annotation"},
@@ -137,7 +139,7 @@ public class ParserTest {
         "}",
       },
       {"SomeAnnotation"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"lambda"},
@@ -152,7 +154,7 @@ public class ParserTest {
         "}",
       },
       {"b", "Integer", "BiFunction"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"switchBlock"},
@@ -174,7 +176,7 @@ public class ParserTest {
         "}",
       },
       {"c"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"tryCatchFinally"},
@@ -196,7 +198,7 @@ public class ParserTest {
         "}",
       },
       {"SomeException", "Exception", "a", "b", "c", "e"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"tryWithResource"},
@@ -218,7 +220,7 @@ public class ParserTest {
         "}",
       },
       {"SomeException", "Exception", "a", "b", "c", "e", "r"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"localInheritence"},
@@ -251,7 +253,14 @@ public class ParserTest {
         "}",
       },
       {"b", "n"},
-      {},
+      {
+        ClassEntity.named("Test").members(ImmutableSet.of("OtherChild", "Child", "Parent")),
+        ClassEntity.namedAndExtending("OtherChild", ClassSelectors.of("Child"))
+            .members(ImmutableSet.of("m")),
+        ClassEntity.namedAndExtending("Child", ClassSelectors.of("Parent"))
+            .members(ImmutableSet.of("f")),
+        ClassEntity.named("Parent").members(ImmutableSet.of("a", "p", "g", "h"))
+      },
     },
     {
       {"annotationParameters"},
@@ -266,7 +275,7 @@ public class ParserTest {
         "}",
       },
       {"Annotation", "Function"},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
     },
     {
       {"typeParameters"},
@@ -280,7 +289,7 @@ public class ParserTest {
         "}",
       },
       {},
-      {},
+      {ClassEntity.named("Test").members(ImmutableSet.of("f", "R"))},
     },
     {
       {"realisticFile"},
@@ -946,7 +955,102 @@ public class ParserTest {
         "Integer",
         "SafeVarargs",
       },
-      {},
+      {
+        ClassEntity.namedAndExtending("ImmutableSet", ClassSelectors.of("ImmutableCollection"))
+            .members(
+                ImmutableSet.of(
+                    "Builder",
+                    "E",
+                    "Indexed",
+                    "JdkBackedSetBuilderImpl",
+                    "RegularSetBuilderImpl",
+                    "SerializedForm",
+                    "SetBuilderImpl",
+                    "<init>",
+                    "SPLITERATOR_CHARACTERISTICS",
+                    "toImmutableSet",
+                    "of",
+                    "constructUnknownDuplication",
+                    "construct",
+                    "copyOf",
+                    "copyOfEnumSet",
+                    "isHashCodeFast",
+                    "equals",
+                    "hashCode",
+                    "iterator",
+                    "asList",
+                    "createAsList",
+                    "writeReplace",
+                    "builder",
+                    "builderWithExpectedSize",
+                    "rebuildHashTable",
+                    "MAX_TABLE_SIZE",
+                    "DESIRED_LOAD_FACTOR",
+                    "CUTOFF",
+                    "chooseTableSize",
+                    "HASH_FLOODING_FPP",
+                    "MAX_RUN_MULTIPLIER",
+                    "hashFloodingDetected",
+                    "maxRunBeforeFallback")),
+        ClassEntity.namedAndExtending("Indexed", ClassSelectors.of("ImmutableSet"))
+            .members(
+                ImmutableSet.of(
+                    "E",
+                    "get",
+                    "iterator",
+                    "spliterator",
+                    "forEach",
+                    "copyIntoArray",
+                    "createAsList")),
+        ClassEntity.named("SerializedForm")
+            .members(ImmutableSet.of("<init>", "elements", "readResolve", "serialVersionUID")),
+        ClassEntity.namedAndExtending(
+                "Builder", ClassSelectors.of("ImmutableCollection", "Builder"))
+            .members(
+                ImmutableSet.of(
+                    "<init>",
+                    "E",
+                    "impl",
+                    "forceCopy",
+                    "forceJdk",
+                    "copyIfNecessary",
+                    "copy",
+                    "add",
+                    "addAll",
+                    "combine",
+                    "build")),
+        ClassEntity.named("SetBuilderImpl")
+            .members(
+                ImmutableSet.of(
+                    "<init>",
+                    "E",
+                    "dedupedElements",
+                    "distinct",
+                    "ensureCapacity",
+                    "addDedupedElement",
+                    "add",
+                    "combine",
+                    "copy",
+                    "review",
+                    "build")),
+        ClassEntity.namedAndExtending("RegularSetBuilderImpl", ClassSelectors.of("SetBuilderImpl"))
+            .members(
+                ImmutableSet.of(
+                    "<init>",
+                    "E",
+                    "hashTable",
+                    "maxRunBeforeFallback",
+                    "expandTableThreshold",
+                    "hashCode",
+                    "ensureTableCapacity",
+                    "add",
+                    "copy",
+                    "review",
+                    "build")),
+        ClassEntity.namedAndExtending(
+                "JdkBackedSetBuilderImpl", ClassSelectors.of("SetBuilderImpl"))
+            .members(ImmutableSet.of("<init>", "E", "delegate", "add", "copy", "build"))
+      },
     },
   };
 
@@ -990,7 +1094,9 @@ public class ParserTest {
 
     assertThat(allUnresolvedIn(got)).containsExactlyElementsIn(expected);
     if (expectedClasses.length > 0) {
-      // TODO: class hierarchy check
+      com.google.common.truth.Truth8.assertThat(got.classes())
+          .containsExactly(expectedClasses)
+          .inOrder();
     }
   }
 }

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/chainExtendClassInPackage/B
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/chainExtendClassInPackage/B
@@ -1,0 +1,5 @@
+package chainExtendClassInPackage;
+
+class B extends C {
+  void List() {}
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/chainExtendClassInPackage/C
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/chainExtendClassInPackage/C
@@ -1,0 +1,5 @@
+package chainExtendClassInPackage;
+
+class C extends A.D {
+  void ArrayList() {}
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/chainExtendClassInPackage/chainExtendClassInPackage.input
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/chainExtendClassInPackage/chainExtendClassInPackage.input
@@ -1,0 +1,14 @@
+// Test that we can properly chain extensions
+package chainExtendClassInPackage;
+
+class A extends B {
+  void main() {
+    List();
+    ArrayList();
+    App();
+  }
+
+  static class D {
+    void App() {}
+  }
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/chainExtendClassInPackage/chainExtendClassInPackage.output
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/chainExtendClassInPackage/chainExtendClassInPackage.output
@@ -1,0 +1,14 @@
+// Test that we can properly chain extensions
+package chainExtendClassInPackage;
+
+class A extends B {
+  void main() {
+    List();
+    ArrayList();
+    App();
+  }
+
+  static class D {
+    void App() {}
+  }
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/extendClassInPackage/Base
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/extendClassInPackage/Base
@@ -1,0 +1,5 @@
+package extendClassInPackage;
+
+class Base {
+  void List() {}
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/extendClassInPackage/extendClassInPackage.input
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/extendClassInPackage/extendClassInPackage.input
@@ -1,0 +1,8 @@
+// Check that we can extend a class if its superclass is in the package
+package extendClassInPackage;
+
+class Test extends Base {
+  void main() {
+    List();
+  }
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/extendClassInPackage/extendClassInPackage.output
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/extendClassInPackage/extendClassInPackage.output
@@ -1,0 +1,8 @@
+// Check that we can extend a class if its superclass is in the package
+package extendClassInPackage;
+
+class Test extends Base {
+  void main() {
+    List();
+  }
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/partialExtendClassInPackage/B
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/partialExtendClassInPackage/B
@@ -1,0 +1,5 @@
+package partialExtendClassInPackage;
+
+class B extends C {
+  void List() {}
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/partialExtendClassInPackage/partialExtendClassInPackage.input
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/partialExtendClassInPackage/partialExtendClassInPackage.input
@@ -1,0 +1,9 @@
+// Test that we partially extend then complete with imports when we cannot find the missing class
+package partialExtendClassInPackage;
+
+class A extends B {
+  void main() {
+    List();
+    ArrayList();
+  }
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/partialExtendClassInPackage/partialExtendClassInPackage.output
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/partialExtendClassInPackage/partialExtendClassInPackage.output
@@ -1,0 +1,9 @@
+// Test that we partially extend then complete with imports when we cannot find the missing class
+package partialExtendClassInPackage;import java.util.ArrayList;
+
+class A extends B {
+  void main() {
+    List();
+    ArrayList();
+  }
+}


### PR DESCRIPTION
* Improved support for class extension: javaimports will now completely resolve extension clauses that point to the same folder as the file to fix.