### PR TITLE
Refactor: replace current candidate selection by `CandidateSelectionStrategy`.

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/common/Identifier.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Identifier.java
@@ -1,0 +1,35 @@
+package com.nikodoko.javaimports.common;
+
+import java.util.Objects;
+
+public final class Identifier {
+  private final String value;
+
+  public Identifier(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (!(o instanceof Identifier)) {
+      return false;
+    }
+
+    var that = (Identifier) o;
+    return Objects.equals(this.value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/common/Import.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Import.java
@@ -4,14 +4,16 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 public final class Import {
-  private final String pkg;
   private final Selector selector;
   private final boolean isStatic;
 
-  public Import(String pkg, Selector selector, boolean isStatic) {
-    this.pkg = pkg;
+  public Import(Selector selector, boolean isStatic) {
     this.selector = selector;
     this.isStatic = isStatic;
+  }
+
+  public Identifier identifier() {
+    return selector.identifier();
   }
 
   @Override
@@ -25,20 +27,17 @@ public final class Import {
     }
 
     var that = (Import) o;
-    return Objects.equals(that.pkg, this.pkg)
-        && Objects.equals(that.selector, this.selector)
-        && this.isStatic == that.isStatic;
+    return Objects.equals(that.selector, this.selector) && this.isStatic == that.isStatic;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pkg, selector, isStatic);
+    return Objects.hash(selector, isStatic);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("pkg", pkg)
         .add("selector", selector)
         .add("isStatic", isStatic)
         .toString();

--- a/core/src/main/java/com/nikodoko/javaimports/common/Import.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Import.java
@@ -4,16 +4,12 @@ import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
 public final class Import {
-  private final Selector selector;
-  private final boolean isStatic;
+  public final Selector selector;
+  public final boolean isStatic;
 
   public Import(Selector selector, boolean isStatic) {
     this.selector = selector;
     this.isStatic = isStatic;
-  }
-
-  public Identifier identifier() {
-    return selector.identifier();
   }
 
   @Override

--- a/core/src/main/java/com/nikodoko/javaimports/common/Import.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Import.java
@@ -1,0 +1,46 @@
+package com.nikodoko.javaimports.common;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+
+public final class Import {
+  private final String pkg;
+  private final Selector selector;
+  private final boolean isStatic;
+
+  public Import(String pkg, Selector selector, boolean isStatic) {
+    this.pkg = pkg;
+    this.selector = selector;
+    this.isStatic = isStatic;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (!(o instanceof Import)) {
+      return false;
+    }
+
+    var that = (Import) o;
+    return Objects.equals(that.pkg, this.pkg)
+        && Objects.equals(that.selector, this.selector)
+        && this.isStatic == that.isStatic;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pkg, selector, isStatic);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("pkg", pkg)
+        .add("selector", selector)
+        .add("isStatic", isStatic)
+        .toString();
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/common/ImportProvider.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/ImportProvider.java
@@ -1,0 +1,6 @@
+package com.nikodoko.javaimports.common;
+
+@FunctionalInterface
+public interface ImportProvider {
+  public Iterable<Import> findImports(Identifier i);
+}

--- a/core/src/main/java/com/nikodoko/javaimports/common/ImportProvider.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/ImportProvider.java
@@ -1,6 +1,8 @@
 package com.nikodoko.javaimports.common;
 
+import java.util.Collection;
+
 @FunctionalInterface
 public interface ImportProvider {
-  public Iterable<Import> findImports(Identifier i);
+  public Collection<Import> findImports(Identifier i);
 }

--- a/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -14,6 +15,7 @@ public final class Selector {
   private final LinkedList<Identifier> identifiers;
 
   private Selector(Collection<Identifier> identifiers) {
+    // TODO: assert that the size is at least one
     this.identifiers = new LinkedList<>(identifiers);
   }
 
@@ -25,6 +27,15 @@ public final class Selector {
     var l = new LinkedList<Identifier>();
     identifiers.forEach(s -> l.add(new Identifier(s)));
     return new Selector(l);
+  }
+
+  public Identifier identifier() {
+    return identifiers.getLast();
+  }
+
+  public Optional<Selector> expression() {
+    // TODO: implement
+    return null;
   }
 
   @Override

--- a/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
@@ -1,0 +1,54 @@
+package com.nikodoko.javaimports.common;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A {@code Selector} describes a single java identifier or selector expression (list of identifiers
+ * separated by a dot).
+ */
+public final class Selector {
+  private final LinkedList<Identifier> identifiers;
+
+  private Selector(Collection<Identifier> identifiers) {
+    this.identifiers = new LinkedList<>(identifiers);
+  }
+
+  public static Selector of(String... identifiers) {
+    return of(Arrays.asList(identifiers));
+  }
+
+  public static Selector of(Iterable<String> identifiers) {
+    var l = new LinkedList<Identifier>();
+    identifiers.forEach(s -> l.add(new Identifier(s)));
+    return new Selector(l);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+
+      return false;
+    }
+
+    if (!(o instanceof Selector)) {
+      return false;
+    }
+
+    var that = (Selector) o;
+    return Objects.equals(this.identifiers, that.identifiers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(identifiers);
+  }
+
+  @Override
+  public String toString() {
+    return identifiers.stream().map(Identifier::toString).collect(Collectors.joining("."));
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
@@ -7,6 +7,7 @@ import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A {@code Selector} describes a single java identifier or selector expression (list of identifiers
@@ -16,7 +17,11 @@ public final class Selector {
   private final LinkedList<Identifier> identifiers;
 
   private Selector(Collection<Identifier> identifiers) {
-    // TODO: assert that the size is at least one
+    if (identifiers.isEmpty()) {
+      throw new IllegalArgumentException(
+          "cannot construct selector from an empty list of identifiers");
+    }
+
     this.identifiers = new LinkedList<>(identifiers);
   }
 
@@ -41,6 +46,44 @@ public final class Selector {
 
   public Optional<Selector> expression() {
     // TODO: implement
+    return null;
+  }
+
+  /**
+   * Constructs a new {@code Selector} by joining this selector to {@code other}.
+   *
+   * <p>This requires the last identifier of this selector to be equal to the first identifier of
+   * the other, and the join will happen on that common identifier.
+   *
+   * <p>For example, if this selector represents {@code "a.b"}, then invoking this method with a
+   * selector representing {@code "b.c"} will return a path representing {@code "a.b.c"}
+   *
+   * @param other the selector to join to this selector
+   * @return the resulting selector
+   * @exception IllegalArgumentException if {@code other} cannot be joined to this {@code Selector}
+   */
+  public Selector join(Selector other) {
+    if (!other.identifiers.peekFirst().equals(identifiers.peekLast())) {
+      throw new IllegalArgumentException("cannot join these selectors");
+    }
+
+    var combined =
+        Stream.concat(identifiers.stream(), other.identifiers.stream().skip(1))
+            .collect(Collectors.toList());
+
+    return new Selector(combined);
+  }
+
+  public Selector subtract(Selector other) {
+    // var minuend = identifiers.descendingIterator();
+    // for (var identifier : other.identifiers.descendingIterator()) {
+    //   if (!minuend.hasNext() || !minuend.next().equals(identifier)) {
+    //     throw new IllegalArgumentException(
+    //         String.format("%s cannot be subtracted from %s", other, this));
+    //   }
+    // }
+
+    // var rest = new ArrayList<Identifier>();
     return null;
   }
 

--- a/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
@@ -1,5 +1,6 @@
 package com.nikodoko.javaimports.common;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -19,8 +20,12 @@ public final class Selector {
     this.identifiers = new LinkedList<>(identifiers);
   }
 
-  public static Selector of(String... identifiers) {
-    return of(Arrays.asList(identifiers));
+  /** Converts a sequence of one or more strings to a {@code Selector}. */
+  public static Selector of(String first, String... more) {
+    var identifiers = new ArrayList<String>();
+    identifiers.add(first);
+    identifiers.addAll(Arrays.asList(more));
+    return of(identifiers);
   }
 
   public static Selector of(Iterable<String> identifiers) {
@@ -29,6 +34,7 @@ public final class Selector {
     return new Selector(l);
   }
 
+  /** Returns the rightmost identifier of this {@code Selector}. */
   public Identifier identifier() {
     return identifiers.getLast();
   }

--- a/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,11 +44,6 @@ public final class Selector {
     return identifiers.getLast();
   }
 
-  public Optional<Selector> expression() {
-    // TODO: implement
-    return null;
-  }
-
   /**
    * Constructs a new {@code Selector} by joining this selector to {@code other}.
    *
@@ -56,7 +51,7 @@ public final class Selector {
    * the other, and the join will happen on that common identifier.
    *
    * <p>For example, if this selector represents {@code "a.b"}, then invoking this method with a
-   * selector representing {@code "b.c"} will return a path representing {@code "a.b.c"}
+   * selector representing {@code "b.c"} will return a path representing {@code "a.b.c"}.
    *
    * @param other the selector to join to this selector
    * @return the resulting selector
@@ -74,17 +69,40 @@ public final class Selector {
     return new Selector(combined);
   }
 
+  /**
+   * Constructs a new {@code Selector} by subtracting {@code other} from this selector.
+   *
+   * <p>This operation is the opposite of {@link #join(Selector)}, so {@code
+   * selector.join(other).subtract(other).equals(selector) == true}.
+   *
+   * <p>For example, if this selector represents {@code "a.b.c"}, then invoking this method with a
+   * selector representing {@code "b.c"} will return a path representing {@code "a.b"}.
+   *
+   * @param other the selector to subtract to this selector
+   * @return the resulting selector
+   * @exception IllegalArgumentException if {@code other} cannot be subtracted from this {@code
+   *     Selector}
+   */
   public Selector subtract(Selector other) {
-    // var minuend = identifiers.descendingIterator();
-    // for (var identifier : other.identifiers.descendingIterator()) {
-    //   if (!minuend.hasNext() || !minuend.next().equals(identifier)) {
-    //     throw new IllegalArgumentException(
-    //         String.format("%s cannot be subtracted from %s", other, this));
-    //   }
-    // }
+    if (!endsWith(other)) {
+      throw new IllegalArgumentException(
+          String.format("%s cannot be subtracted from %s", other, this));
+    }
 
-    // var rest = new ArrayList<Identifier>();
-    return null;
+    // The +1 is to keep the last common identifier
+    var cutoff = identifiers.size() - other.identifiers.size() + 1;
+    return new Selector(List.copyOf(identifiers.subList(0, cutoff)));
+  }
+
+  /** Returns true if this {@code Selector} ends with {@code other}. */
+  public boolean endsWith(Selector other) {
+    var thisLength = identifiers.size();
+    var otherLength = other.identifiers.size();
+    if (otherLength > thisLength) {
+      return false;
+    }
+
+    return identifiers.subList(thisLength - otherLength, thisLength).equals(other.identifiers);
   }
 
   @Override

--- a/core/src/main/java/com/nikodoko/javaimports/environment/Environment.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/Environment.java
@@ -1,5 +1,6 @@
 package com.nikodoko.javaimports.environment;
 
+import com.nikodoko.javaimports.common.ImportProvider;
 import com.nikodoko.javaimports.parser.Import;
 import com.nikodoko.javaimports.parser.ParsedFile;
 import java.util.Optional;
@@ -9,7 +10,7 @@ import java.util.Set;
  * A build system-agnostic representation of a Java project's environment, that can be queried to
  * get information about importable symbols.
  */
-public interface Environment {
+public interface Environment extends ImportProvider {
   /** Searches for the best available import with the given {@code identifier}. */
   Optional<Import> search(String identifier);
 

--- a/core/src/main/java/com/nikodoko/javaimports/environment/Environments.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/Environments.java
@@ -1,13 +1,16 @@
 package com.nikodoko.javaimports.environment;
 
 import com.nikodoko.javaimports.Options;
+import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.environment.maven.MavenEnvironment;
 import com.nikodoko.javaimports.parser.Import;
 import com.nikodoko.javaimports.parser.ParsedFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -21,6 +24,11 @@ public class Environments {
     @Override
     public Set<ParsedFile> filesInPackage(String packageName) {
       return new HashSet<>();
+    }
+
+    @Override
+    public Collection<com.nikodoko.javaimports.common.Import> findImports(Identifier i) {
+      return List.of();
     }
   }
 

--- a/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenEnvironment.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenEnvironment.java
@@ -3,6 +3,7 @@ package com.nikodoko.javaimports.environment.maven;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.nikodoko.javaimports.Options;
+import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.environment.Environment;
 import com.nikodoko.javaimports.environment.JavaProject;
 import com.nikodoko.javaimports.environment.PackageDistance;
@@ -13,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -66,6 +68,20 @@ public class MavenEnvironment implements Environment {
     }
 
     return Optional.ofNullable(bestAvailableImports.get(identifier));
+  }
+
+  @Override
+  public Collection<com.nikodoko.javaimports.common.Import> findImports(Identifier i) {
+    if (!isInitialized) {
+      init();
+    }
+
+    var best = bestAvailableImports.get(i.toString());
+    if (best == null) {
+      return List.of();
+    }
+
+    return List.of(best.toNew());
   }
 
   private void init() {

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/Fixer.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/Fixer.java
@@ -4,7 +4,6 @@ import com.nikodoko.javaimports.Options;
 import com.nikodoko.javaimports.environment.Environment;
 import com.nikodoko.javaimports.fixer.internal.LoadResult;
 import com.nikodoko.javaimports.fixer.internal.Loader;
-import com.nikodoko.javaimports.parser.ClassExtender;
 import com.nikodoko.javaimports.parser.Import;
 import com.nikodoko.javaimports.parser.ParsedFile;
 import com.nikodoko.javaimports.stdlib.StdlibProvider;
@@ -84,41 +83,38 @@ public class Fixer {
   // Gives up if all necessary imports cannot be found, except if it is a last try, in which case
   // the best possible incomplete list of fixes will be returned.
   private Result fix(boolean lastTry) {
-    boolean allGood = true;
-    Set<Import> fixes = new HashSet<>();
-    LoadResult loaded = loader.result();
-    for (String ident : loaded.unresolved) {
-      Optional<Import> maybeFix = loaded.candidates.get(ident);
-      if (maybeFix.isPresent()) {
-        fixes.add(maybeFix.get());
-        continue;
-      }
-
-      allGood = false;
-    }
-
-    // We have found all necessary fixes
-    if (allGood && loaded.orphans.isEmpty()) {
-      return Result.complete(fixes);
-    }
-
-    // This is not the last try, we can probably find more fixes next try
-    if (!lastTry) {
+    var loaded = loader.result();
+    if (!loaded.orphans.isEmpty() && !lastTry) {
       return Result.incomplete();
     }
 
-    // We did not find everything, do our best effort by trying to resolve anything we can in non
-    // resolved orphan classes
-    for (ClassExtender orphan : loaded.orphans) {
-      for (String ident : orphan.notYetResolved()) {
-        Optional<Import> maybeFix = loaded.candidates.get(ident);
-        if (maybeFix.isPresent()) {
-          fixes.add(maybeFix.get());
-        }
-      }
+    var unresolved = allUnresolved(loaded);
+    var fixes = findFixes(unresolved, loaded);
+    var allGood = fixes.size() == unresolved.size();
+
+    if (allGood) {
+      return Result.complete(fixes);
     }
 
     return Result.incomplete(fixes);
+  }
+
+  private Set<Import> findFixes(Set<String> unresolved, LoadResult loaded) {
+    Set<Import> fixes =
+        unresolved.stream()
+            .map(loaded.candidates::get)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toSet());
+
+    return fixes;
+  }
+
+  private Set<String> allUnresolved(LoadResult loaded) {
+    var allUnresolved = new HashSet<String>();
+    allUnresolved.addAll(loaded.unresolved);
+    loaded.orphans.stream().forEach(o -> allUnresolved.addAll(o.notYetResolved()));
+    return allUnresolved;
   }
 
   /**

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/Fixer.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/Fixer.java
@@ -3,7 +3,6 @@ package com.nikodoko.javaimports.fixer;
 import com.nikodoko.javaimports.Options;
 import com.nikodoko.javaimports.common.Selector;
 import com.nikodoko.javaimports.environment.Environment;
-import com.nikodoko.javaimports.fixer.candidates.BestCandidates;
 import com.nikodoko.javaimports.fixer.candidates.CandidateFinder;
 import com.nikodoko.javaimports.fixer.candidates.CandidateSelectionStrategy;
 import com.nikodoko.javaimports.fixer.candidates.Candidates;
@@ -127,10 +126,8 @@ public class Fixer {
     var finder = new CandidateFinder();
     var selectors = unresolved.stream().map(Selector::of).collect(Collectors.toList());
     var candidates = selectors.stream().map(finder::find).reduce(Candidates::merge).get();
-    CandidateSelectionStrategy dummy = (cand, curr) -> new BestCandidates();
-    var best =
-        dummy.selectBest(
-            candidates, current.stream().map(Import::toNew).collect(Collectors.toList()));
+    CandidateSelectionStrategy dummy = cand -> null;
+    var best = dummy.selectBest(candidates);
 
     return selectors.stream()
         .map(best::forSelector)

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/BasicCandidateSelectionStrategy.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/BasicCandidateSelectionStrategy.java
@@ -1,0 +1,34 @@
+package com.nikodoko.javaimports.fixer.candidates;
+
+import com.nikodoko.javaimports.common.Import;
+import java.util.Collection;
+import java.util.Collections;
+
+public class BasicCandidateSelectionStrategy implements CandidateSelectionStrategy {
+  @Override
+  public BestCandidates selectBest(Candidates candidates) {
+    var builder = BestCandidates.builder();
+    for (var selector : candidates.selectors()) {
+      builder.put(selector, bestSource(candidates.getFor(selector)));
+    }
+
+    return builder.build();
+  }
+
+  private Import bestSource(Collection<Candidate> candidates) {
+    return Collections.max(candidates, (c1, c2) -> sourceValue(c1) - sourceValue(c2)).i;
+  }
+
+  private int sourceValue(Candidate candidate) {
+    switch (candidate.s) {
+      case SIBLING:
+        return 2;
+      case STDLIB:
+        return 1;
+      case EXTERNAL:
+        return 0;
+      default:
+        return -1;
+    }
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/BestCandidates.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/BestCandidates.java
@@ -1,0 +1,11 @@
+package com.nikodoko.javaimports.fixer.candidates;
+
+import com.nikodoko.javaimports.common.Import;
+import com.nikodoko.javaimports.common.Selector;
+import java.util.Optional;
+
+public class BestCandidates {
+  public Optional<Import> forSelector(Selector selector) {
+    return null;
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/BestCandidates.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/BestCandidates.java
@@ -1,11 +1,62 @@
 package com.nikodoko.javaimports.fixer.candidates;
 
+import com.google.common.base.MoreObjects;
 import com.nikodoko.javaimports.common.Import;
 import com.nikodoko.javaimports.common.Selector;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 public class BestCandidates {
+  private final Map<Selector, Import> imports;
+
+  private BestCandidates(Map<Selector, Import> imports) {
+    this.imports = imports;
+  }
+
   public Optional<Import> forSelector(Selector selector) {
     return null;
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (!(o instanceof BestCandidates)) {
+      return false;
+    }
+
+    var that = (BestCandidates) o;
+    return Objects.equals(this.imports, that.imports);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(imports);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("imports", imports).toString();
+  }
+
+  static class Builder {
+    private Map<Selector, Import> imports = new HashMap<>();
+
+    Builder put(Selector s, Import i) {
+      imports.put(s, i);
+      return this;
+    }
+
+    BestCandidates build() {
+      return new BestCandidates(imports);
+    }
   }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/BestCandidates.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/BestCandidates.java
@@ -16,7 +16,7 @@ public class BestCandidates {
   }
 
   public Optional<Import> forSelector(Selector selector) {
-    return null;
+    return Optional.ofNullable(imports.get(selector));
   }
 
   static Builder builder() {

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidate.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidate.java
@@ -4,8 +4,8 @@ import com.google.common.base.MoreObjects;
 import com.nikodoko.javaimports.common.Import;
 import java.util.Objects;
 
-final class Candidate {
-  static enum Source {
+public final class Candidate {
+  public static enum Source {
     SIBLING,
     STDLIB,
     EXTERNAL;

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidate.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidate.java
@@ -1,0 +1,45 @@
+package com.nikodoko.javaimports.fixer.candidates;
+
+import com.google.common.base.MoreObjects;
+import com.nikodoko.javaimports.common.Import;
+import java.util.Objects;
+
+final class Candidate {
+  static enum Source {
+    SIBLING,
+    STDLIB,
+    EXTERNAL;
+  }
+
+  final Import i;
+  final Source s;
+
+  Candidate(Import i, Source s) {
+    this.i = i;
+    this.s = s;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (!(o instanceof Candidate)) {
+      return false;
+    }
+
+    var that = (Candidate) o;
+    return Objects.equals(this.i, that.i) && Objects.equals(this.s, that.s);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(i, s);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("import", i).add("source", s).toString();
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinder.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinder.java
@@ -1,12 +1,42 @@
 package com.nikodoko.javaimports.fixer.candidates;
 
+import static java.nio.channels.spi.AsynchronousChannelProvider.provider;
+
+import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.common.ImportProvider;
 import com.nikodoko.javaimports.common.Selector;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class CandidateFinder {
-  public void add(Candidate.Source source, ImportProvider... providers) {}
+  private Map<Candidate.Source, List<ImportProvider>> providers = new HashMap<>();
+
+  public void add(Candidate.Source source, ImportProvider... additional) {
+    var current = providers.computeIfAbsent(source, __ -> new ArrayList<>());
+    Collections.addAll(current, additional);
+  }
 
   public Candidates find(Selector selector) {
-    return Candidates.EMPTY;
+    var candidates = allFor(selector.identifier());
+    if (candidates.size() == 0) {
+      return Candidates.EMPTY;
+    }
+
+    return Candidates.forSelector(selector).add(allFor(selector.identifier())).build();
+  }
+
+  private List<Candidate> allFor(Identifier identifier) {
+    var all = new ArrayList<Candidate>();
+    for (var entry : providers.entrySet()) {
+      entry.getValue().stream()
+          .flatMap(provider -> provider.findImports(identifier).stream())
+          .map(i -> new Candidate(i, entry.getKey()))
+          .forEach(all::add);
+    }
+
+    return all;
   }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinder.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinder.java
@@ -1,8 +1,7 @@
 package com.nikodoko.javaimports.fixer.candidates;
 
-import static java.nio.channels.spi.AsynchronousChannelProvider.provider;
-
 import com.nikodoko.javaimports.common.Identifier;
+import com.nikodoko.javaimports.common.Import;
 import com.nikodoko.javaimports.common.ImportProvider;
 import com.nikodoko.javaimports.common.Selector;
 import java.util.ArrayList;
@@ -10,6 +9,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CandidateFinder {
   private Map<Candidate.Source, List<ImportProvider>> providers = new HashMap<>();
@@ -20,23 +21,38 @@ public class CandidateFinder {
   }
 
   public Candidates find(Selector selector) {
-    var candidates = allFor(selector.identifier());
+    var candidates =
+        findForIdentifier(selector.identifier())
+            .filter(c -> matchesSelector(c, selector))
+            .map(c -> truncate(c, selector))
+            .collect(Collectors.toList());
     if (candidates.size() == 0) {
       return Candidates.EMPTY;
     }
 
-    return Candidates.forSelector(selector).add(allFor(selector.identifier())).build();
+    return Candidates.forSelector(selector).add(candidates).build();
   }
 
-  private List<Candidate> allFor(Identifier identifier) {
-    var all = new ArrayList<Candidate>();
-    for (var entry : providers.entrySet()) {
-      entry.getValue().stream()
-          .flatMap(provider -> provider.findImports(identifier).stream())
-          .map(i -> new Candidate(i, entry.getKey()))
-          .forEach(all::add);
-    }
+  // A candidate matches a selector if the underlying import's selector ends with it.
+  private boolean matchesSelector(Candidate candidate, Selector selector) {
+    return candidate.i.selector.endsWith(selector);
+  }
 
-    return all;
+  private Candidate truncate(Candidate candidate, Selector selector) {
+    var importForSelector =
+        new Import(candidate.i.selector.subtract(selector), candidate.i.isStatic);
+    return new Candidate(importForSelector, candidate.s);
+  }
+
+  private Stream<Candidate> findForIdentifier(Identifier identifier) {
+    return providers.entrySet().stream()
+        .flatMap(e -> generateCandidates(e.getKey(), e.getValue(), identifier));
+  }
+
+  private Stream<Candidate> generateCandidates(
+      Candidate.Source source, List<ImportProvider> providers, Identifier identifier) {
+    return providers.stream()
+        .flatMap(p -> p.findImports(identifier).stream())
+        .map(i -> new Candidate(i, source));
   }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinder.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinder.java
@@ -1,0 +1,12 @@
+package com.nikodoko.javaimports.fixer.candidates;
+
+import com.nikodoko.javaimports.common.ImportProvider;
+import com.nikodoko.javaimports.common.Selector;
+
+public class CandidateFinder {
+  public void add(Candidate.Source source, ImportProvider... providers) {}
+
+  public Candidates find(Selector selector) {
+    return Candidates.EMPTY;
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateSelectionStrategy.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateSelectionStrategy.java
@@ -1,0 +1,12 @@
+package com.nikodoko.javaimports.fixer.candidates;
+
+import com.nikodoko.javaimports.common.Import;
+import java.util.Collection;
+
+public interface CandidateSelectionStrategy {
+  /**
+   * Select the best candidate for each selector in {@code candidates}, maybe using the {@code
+   * current} imports to refine that selection.
+   */
+  BestCandidates selectBest(Candidates candidates, Collection<Import> current);
+}

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateSelectionStrategy.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/CandidateSelectionStrategy.java
@@ -1,12 +1,6 @@
 package com.nikodoko.javaimports.fixer.candidates;
 
-import com.nikodoko.javaimports.common.Import;
-import java.util.Collection;
-
 public interface CandidateSelectionStrategy {
-  /**
-   * Select the best candidate for each selector in {@code candidates}, maybe using the {@code
-   * current} imports to refine that selection.
-   */
-  BestCandidates selectBest(Candidates candidates, Collection<Import> current);
+  /** Select the best candidate for each selector in {@code candidates}. */
+  BestCandidates selectBest(Candidates candidates);
 }

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidates.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidates.java
@@ -5,11 +5,12 @@ import com.nikodoko.javaimports.common.Selector;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-class Candidates {
+public class Candidates {
   static final Candidates EMPTY = new Candidates(Map.of());
 
   private final Map<Selector, List<Candidate>> candidates;
@@ -28,6 +29,13 @@ class Candidates {
 
   static Builder forSelector(Selector s) {
     return new Builder(s);
+  }
+
+  public static Candidates merge(Candidates a, Candidates b) {
+    var combined = new HashMap<Selector, List<Candidate>>();
+    combined.putAll(a.candidates);
+    combined.putAll(b.candidates);
+    return new Candidates(combined);
   }
 
   @Override

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidates.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidates.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class Candidates {
   static final Candidates EMPTY = new Candidates(Map.of());
@@ -19,10 +20,23 @@ public class Candidates {
     this.candidates = candidates;
   }
 
+  /**
+   * Returns a list of {@link Candidate} for this {@code selector}, or an empty list if none are
+   * present.
+   */
   List<Candidate> getFor(Selector selector) {
-    return null;
+    return candidates.getOrDefault(selector, new ArrayList<>());
   }
 
+  /**
+   * Returns all the selectors for which this {@code Candidates} contains one or more {@link
+   * Candidate}.
+   */
+  Set<Selector> selectors() {
+    return candidates.keySet();
+  }
+
+  /** Returns true if this {@code Candidates} does not contain any candidates. */
   boolean isEmpty() {
     return candidates.isEmpty();
   }
@@ -31,6 +45,10 @@ public class Candidates {
     return new Builder(s);
   }
 
+  /**
+   * Creates a new instance of {@code Candidates} containing all the candidates stored in {@code a}
+   * and {@code b}.
+   */
   public static Candidates merge(Candidates a, Candidates b) {
     var combined = new HashMap<Selector, List<Candidate>>();
     combined.putAll(a.candidates);

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidates.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidates.java
@@ -1,0 +1,9 @@
+package com.nikodoko.javaimports.fixer.candidates;
+
+public class Candidates {
+  public static final Candidates EMPTY = new Candidates();
+
+  boolean isEmpty() {
+    return true;
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidates.java
+++ b/core/src/main/java/com/nikodoko/javaimports/fixer/candidates/Candidates.java
@@ -1,9 +1,79 @@
 package com.nikodoko.javaimports.fixer.candidates;
 
-public class Candidates {
-  public static final Candidates EMPTY = new Candidates();
+import com.google.common.base.MoreObjects;
+import com.nikodoko.javaimports.common.Selector;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+class Candidates {
+  static final Candidates EMPTY = new Candidates(Map.of());
+
+  private final Map<Selector, List<Candidate>> candidates;
+
+  private Candidates(Map<Selector, List<Candidate>> candidates) {
+    this.candidates = candidates;
+  }
+
+  List<Candidate> getFor(Selector selector) {
+    return null;
+  }
 
   boolean isEmpty() {
-    return true;
+    return candidates.isEmpty();
+  }
+
+  static Builder forSelector(Selector s) {
+    return new Builder(s);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+
+    if (!(o instanceof Candidates)) {
+      return false;
+    }
+
+    var that = (Candidates) o;
+    return Objects.equals(this.candidates, that.candidates);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(candidates);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("candidates", candidates).toString();
+  }
+
+  static class Builder {
+    private final Selector selector;
+    private List<Candidate> candidates = new ArrayList<>();
+
+    private Builder(Selector selector) {
+      this.selector = selector;
+    }
+
+    Builder add(Collection<Candidate> candidates) {
+      this.candidates.addAll(candidates);
+      return this;
+    }
+
+    Builder add(Candidate... candidates) {
+      Collections.addAll(this.candidates, candidates);
+      return this;
+    }
+
+    Candidates build() {
+      return new Candidates(Map.of(selector, candidates));
+    }
   }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/parser/Import.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/Import.java
@@ -1,8 +1,10 @@
 package com.nikodoko.javaimports.parser;
 
 import com.google.common.base.MoreObjects;
+import com.nikodoko.javaimports.common.Selector;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCImport;
+import java.util.ArrayList;
 import java.util.Objects;
 
 /** An {@code Import} represents a single import statement. */
@@ -55,6 +57,25 @@ public class Import {
 
   public boolean isInJavaUtil() {
     return qualifier.equals("java.util");
+  }
+
+  // TODO: remove
+  public com.nikodoko.javaimports.common.Import toNew() {
+    var identifiers = new ArrayList<String>();
+    var fragments = qualifier.split("\\.");
+    for (var frag : fragments) {
+      identifiers.add(frag);
+    }
+    identifiers.add(name);
+    return new com.nikodoko.javaimports.common.Import(Selector.of(identifiers), isStatic);
+  }
+
+  public static Import fromNew(com.nikodoko.javaimports.common.Import i) {
+    var str = i.selector.toString();
+    var cutoff = str.lastIndexOf(".");
+    var qualifier = str.substring(0, cutoff);
+    var name = str.substring(cutoff + 1);
+    return new Import(name, qualifier, i.isStatic);
   }
 
   /** Creates a fully qualified import statement from this {@code Import} object. */

--- a/core/src/main/java/com/nikodoko/javaimports/parser/ParsedFile.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/ParsedFile.java
@@ -2,12 +2,15 @@ package com.nikodoko.javaimports.parser;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Range;
+import com.nikodoko.javaimports.common.Identifier;
+import com.nikodoko.javaimports.common.ImportProvider;
 import com.nikodoko.javaimports.parser.internal.ClassEntity;
 import com.nikodoko.javaimports.parser.internal.Scope;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCImport;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +18,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /** An object representing a Java source file. */
-public class ParsedFile {
+public class ParsedFile implements ImportProvider {
   // The name of the package to which this file belongs
   String packageName;
   // The imports in this file
@@ -138,6 +141,15 @@ public class ParsedFile {
 
   public Stream<ClassEntity> classes() {
     return ClassHierarchies.flatView(classHierarchy);
+  }
+
+  // TODO: remove
+  public Collection<com.nikodoko.javaimports.common.Import> findImports(Identifier i) {
+    if (!imports.containsKey(i.toString())) {
+      return List.of();
+    }
+
+    return List.of(imports.get(i.toString()).toNew());
   }
 
   /** Debugging support. */

--- a/core/src/main/java/com/nikodoko/javaimports/stdlib/BasicStdlibProvider.java
+++ b/core/src/main/java/com/nikodoko/javaimports/stdlib/BasicStdlibProvider.java
@@ -1,8 +1,10 @@
 package com.nikodoko.javaimports.stdlib;
 
+import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.parser.Import;
 import com.nikodoko.javaimports.stdlib.internal.Stdlib;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,16 @@ public class BasicStdlibProvider implements StdlibProvider {
     }
 
     return candidates;
+  }
+
+  @Override
+  public Collection<com.nikodoko.javaimports.common.Import> findImports(Identifier i) {
+    var found = find(List.of(i.toString())).get(i.toString());
+    if (found == null) {
+      return List.of();
+    }
+
+    return List.of(found.toNew());
   }
 
   private void updateUsedPackages(Iterable<Import> imports) {

--- a/core/src/main/java/com/nikodoko/javaimports/stdlib/StdlibProvider.java
+++ b/core/src/main/java/com/nikodoko/javaimports/stdlib/StdlibProvider.java
@@ -1,9 +1,10 @@
 package com.nikodoko.javaimports.stdlib;
 
+import com.nikodoko.javaimports.common.ImportProvider;
 import com.nikodoko.javaimports.parser.Import;
 import java.util.Map;
 
-public interface StdlibProvider {
+public interface StdlibProvider extends ImportProvider {
   public Map<String, Import> find(Iterable<String> identifiers);
 
   public boolean isInJavaLang(String identifier);

--- a/core/src/main/java/com/nikodoko/javaimports/stdlib/StdlibProviders.java
+++ b/core/src/main/java/com/nikodoko/javaimports/stdlib/StdlibProviders.java
@@ -1,8 +1,11 @@
 package com.nikodoko.javaimports.stdlib;
 
+import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.parser.Import;
 import com.nikodoko.javaimports.stdlib.internal.api.v8.Java8Stdlib;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class StdlibProviders {
@@ -17,6 +20,11 @@ public class StdlibProviders {
     @Override
     public boolean isInJavaLang(String identifier) {
       return false;
+    }
+
+    @Override
+    public Collection<com.nikodoko.javaimports.common.Import> findImports(Identifier i) {
+      return List.of();
     }
   }
 

--- a/core/src/test/java/com/nikodoko/javaimports/common/CommonTestUtil.java
+++ b/core/src/test/java/com/nikodoko/javaimports/common/CommonTestUtil.java
@@ -1,0 +1,12 @@
+package com.nikodoko.javaimports.common;
+
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+
+/** Test utilities for classes in the {@code common} package. */
+public class CommonTestUtil {
+  public static Arbitrary<List<String>> arbitraryIdentifiers() {
+    return Arbitraries.strings().ascii().ofMinLength(1).list().ofMinSize(1).ofMaxSize(8);
+  }
+}

--- a/core/src/test/java/com/nikodoko/javaimports/common/CommonTestUtil.java
+++ b/core/src/test/java/com/nikodoko/javaimports/common/CommonTestUtil.java
@@ -7,6 +7,6 @@ import net.jqwik.api.Arbitrary;
 /** Test utilities for classes in the {@code common} package. */
 public class CommonTestUtil {
   public static Arbitrary<List<String>> arbitraryIdentifiers() {
-    return Arbitraries.strings().ascii().ofMinLength(1).list().ofMinSize(1).ofMaxSize(8);
+    return Arbitraries.strings().ascii().ofMinLength(2).list().ofMinSize(1).ofMaxSize(8);
   }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/common/SelectorTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/common/SelectorTest.java
@@ -1,0 +1,25 @@
+package com.nikodoko.javaimports.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.List;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.NotEmpty;
+import net.jqwik.api.constraints.Size;
+import net.jqwik.api.constraints.Unique;
+
+public class SelectorTest {
+  @Property
+  void theSelectorConstructorCopiesArguments(
+      @ForAll @Size(min = 1, max = 8) List<@Unique @NotEmpty String> identifiers) {
+    var original = List.copyOf(identifiers);
+    var selector2 =
+        Selector.of(identifiers.get(0), identifiers.stream().skip(1).toArray(String[]::new));
+    var selector1 = Selector.of(identifiers);
+    identifiers.set(0, "");
+    assertThat(selector1).isEqualTo(Selector.of(original));
+    assertThat(selector2).isEqualTo(Selector.of(original));
+  }
+  // by nikodoko.com
+}

--- a/core/src/test/java/com/nikodoko/javaimports/common/SelectorTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/common/SelectorTest.java
@@ -3,16 +3,15 @@ package com.nikodoko.javaimports.common;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.util.List;
+import net.jqwik.api.Arbitrary;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
 import net.jqwik.api.constraints.NotEmpty;
-import net.jqwik.api.constraints.Size;
-import net.jqwik.api.constraints.Unique;
 
 public class SelectorTest {
   @Property
-  void theSelectorConstructorCopiesArguments(
-      @ForAll @Size(min = 1, max = 8) List<@Unique @NotEmpty String> identifiers) {
+  void theSelectorConstructorCopiesArguments(@ForAll("identifiers") List<String> identifiers) {
     var original = List.copyOf(identifiers);
     var selector2 =
         Selector.of(identifiers.get(0), identifiers.stream().skip(1).toArray(String[]::new));
@@ -21,5 +20,27 @@ public class SelectorTest {
     assertThat(selector1).isEqualTo(Selector.of(original));
     assertThat(selector2).isEqualTo(Selector.of(original));
   }
-  // by nikodoko.com
+
+  @Property
+  void joinLeavesOriginalSelectorsUnchanged(
+      @ForAll("identifiers") List<String> first,
+      @ForAll @NotEmpty String common,
+      @ForAll("identifiers") List<String> last) {
+    first.add(common);
+    last.add(0, common);
+    var firstCopy = List.copyOf(first);
+    var lastCopy = List.copyOf(last);
+    var aSelector = Selector.of(first);
+    var anotherSelector = Selector.of(last);
+
+    aSelector.join(anotherSelector);
+
+    assertThat(aSelector).isEqualTo(Selector.of(firstCopy));
+    assertThat(anotherSelector).isEqualTo(Selector.of(lastCopy));
+  }
+
+  @Provide
+  Arbitrary<List<String>> identifiers() {
+    return CommonTestUtil.arbitraryIdentifiers();
+  }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/fixer/candidates/BasicCandidateSelectionStrategyTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/fixer/candidates/BasicCandidateSelectionStrategyTest.java
@@ -1,0 +1,39 @@
+package com.nikodoko.javaimports.fixer.candidates;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.nikodoko.javaimports.common.Import;
+import com.nikodoko.javaimports.common.Selector;
+import org.junit.jupiter.api.Test;
+
+public class BasicCandidateSelectionStrategyTest {
+  @Test
+  void itShouldSelectCandidatesAccordingToSource() {
+    var candidates =
+        Candidates.merge(
+            Candidates.forSelector(Selector.of("A"))
+                .add(
+                    new Candidate(
+                        new Import(Selector.of("com", "pkg", "A"), false), Candidate.Source.STDLIB),
+                    new Candidate(
+                        new Import(Selector.of("com", "another", "pkg", "A"), false),
+                        Candidate.Source.SIBLING))
+                .build(),
+            Candidates.forSelector(Selector.of("B"))
+                .add(
+                    new Candidate(
+                        new Import(Selector.of("com", "pkg", "B"), false), Candidate.Source.STDLIB),
+                    new Candidate(
+                        new Import(Selector.of("com", "another", "pkg", "B"), false),
+                        Candidate.Source.EXTERNAL))
+                .build());
+
+    var expected =
+        BestCandidates.builder()
+            .put(Selector.of("A"), new Import(Selector.of("com", "another", "pkg", "A"), false))
+            .put(Selector.of("B"), new Import(Selector.of("com", "pkg", "B"), false))
+            .build();
+    var got = new BasicCandidateSelectionStrategy().selectBest(candidates);
+    assertThat(got).isEqualTo(expected);
+  }
+}

--- a/core/src/test/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinderTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinderTest.java
@@ -1,45 +1,63 @@
 package com.nikodoko.javaimports.fixer.candidates;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.common.Import;
 import com.nikodoko.javaimports.common.ImportProvider;
 import com.nikodoko.javaimports.common.Selector;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Example;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
 
 public class CandidateFinderTest {
-  static class DummyProvider implements ImportProvider {
-    Map<Identifier, List<Import>> data =
-        Map.of(
-            new Identifier("MyClass"),
-            List.of(new Import("com.myapp", Selector.of("MyClass"), false)),
-            new Identifier("Subclass"),
-            List.of(new Import("com.myapp", Selector.of("MyClass", "Subclass"), false)),
-            new Identifier("CONSTANT"),
-            List.of(
-                new Import("com.myapp", Selector.of("MyClass", "CONSTANT"), true),
-                new Import("com.myapp", Selector.of("MyClass", "Subclass", "CONSTANT"), true)));
-
-    public Iterable<Import> findImports(Identifier identifier) {
-      return Optional.ofNullable(data.get(identifier)).orElse(new ArrayList<>());
-    }
-  }
-
   @Property
   boolean theDefaultCandidateFinderReturnsEmptyCandidates(
       @ForAll("arbitrarySelector") Selector aSelector) {
     return new CandidateFinder().find(aSelector).isEmpty();
   }
 
+  @Example
+  void itShouldReturnImportsMatchingASelectorOfLength1() {
+    var finder = new CandidateFinder();
+    finder.add(
+        Candidate.Source.STDLIB,
+        providerOf("static com.myapp.MyClass.CONSTANT", "com.myapp.MyClass"));
+
+    assertThat(finder.find(Selector.of("MyClass")))
+        .isEqualTo(
+            Candidates.forSelector(Selector.of("MyClass"))
+                .add(new Candidate(importOf("com.myapp.MyClass"), Candidate.Source.STDLIB))
+                .build());
+  }
+
   @Provide
   Arbitrary<Selector> arbitrarySelector() {
     return Arbitraries.strings().all().list().ofMinSize(1).ofMaxSize(10).map(Selector::of);
+  }
+
+  static ImportProvider providerOf(String... importStatements) {
+    var importsByIdentifier = new HashMap<Identifier, List<Import>>();
+    for (String statement : importStatements) {
+      var i = importOf(statement);
+      var imports = importsByIdentifier.computeIfAbsent(i.identifier(), __ -> new ArrayList<>());
+      imports.add(i);
+    }
+
+    return ident -> importsByIdentifier.getOrDefault(ident, new ArrayList<>());
+  }
+
+  static Import importOf(String statement) {
+    var STATIC = "static ";
+    var isStatic = statement.startsWith(STATIC);
+    var trimmed = isStatic ? statement.substring(STATIC.length()) : statement;
+    var fragments = trimmed.split("\\.");
+    return new Import(Selector.of(fragments), isStatic);
   }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinderTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/fixer/candidates/CandidateFinderTest.java
@@ -1,0 +1,45 @@
+package com.nikodoko.javaimports.fixer.candidates;
+
+import com.nikodoko.javaimports.common.Identifier;
+import com.nikodoko.javaimports.common.Import;
+import com.nikodoko.javaimports.common.ImportProvider;
+import com.nikodoko.javaimports.common.Selector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+public class CandidateFinderTest {
+  static class DummyProvider implements ImportProvider {
+    Map<Identifier, List<Import>> data =
+        Map.of(
+            new Identifier("MyClass"),
+            List.of(new Import("com.myapp", Selector.of("MyClass"), false)),
+            new Identifier("Subclass"),
+            List.of(new Import("com.myapp", Selector.of("MyClass", "Subclass"), false)),
+            new Identifier("CONSTANT"),
+            List.of(
+                new Import("com.myapp", Selector.of("MyClass", "CONSTANT"), true),
+                new Import("com.myapp", Selector.of("MyClass", "Subclass", "CONSTANT"), true)));
+
+    public Iterable<Import> findImports(Identifier identifier) {
+      return Optional.ofNullable(data.get(identifier)).orElse(new ArrayList<>());
+    }
+  }
+
+  @Property
+  boolean theDefaultCandidateFinderReturnsEmptyCandidates(
+      @ForAll("arbitrarySelector") Selector aSelector) {
+    return new CandidateFinder().find(aSelector).isEmpty();
+  }
+
+  @Provide
+  Arbitrary<Selector> arbitrarySelector() {
+    return Arbitraries.strings().all().list().ofMinSize(1).ofMaxSize(10).map(Selector::of);
+  }
+}

--- a/core/src/test/java/com/nikodoko/javaimports/parser/ImportTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/parser/ImportTest.java
@@ -1,0 +1,24 @@
+package com.nikodoko.javaimports.parser;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.nikodoko.javaimports.common.Selector;
+import org.junit.jupiter.api.Test;
+
+// TODO: delete
+public class ImportTest {
+  @Test
+  void testToNew() {
+    var oldImport = new Import("Test", "a.b.c", true);
+    assertThat(oldImport.toNew())
+        .isEqualTo(
+            new com.nikodoko.javaimports.common.Import(Selector.of("a", "b", "c", "Test"), true));
+  }
+
+  @Test
+  void testFromNew() {
+    var newImport =
+        new com.nikodoko.javaimports.common.Import(Selector.of("a", "b", "c", "Test"), true);
+    assertThat(Import.fromNew(newImport)).isEqualTo(new Import("Test", "a.b.c", true));
+  }
+}

--- a/core/src/test/java/com/nikodoko/javaimports/stdlib/FakeStdlibProvider.java
+++ b/core/src/test/java/com/nikodoko/javaimports/stdlib/FakeStdlibProvider.java
@@ -1,7 +1,10 @@
 package com.nikodoko.javaimports.stdlib;
 
+import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.parser.Import;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class FakeStdlibProvider implements StdlibProvider {
@@ -30,6 +33,16 @@ public class FakeStdlibProvider implements StdlibProvider {
     }
 
     return found;
+  }
+
+  @Override
+  public Collection<com.nikodoko.javaimports.common.Import> findImports(Identifier i) {
+    var found = imports.get(i.toString());
+    if (found == null) {
+      return List.of();
+    }
+
+    return List.of(found.toNew());
   }
 
   @Override


### PR DESCRIPTION
First step to unify import selection across all providers (sibling files, stdlib, etc.): replace current candidate selection method by `CandidateFinder` and `CandidateSelectionStrategy`.