### PR TITLE
Correctly import subpackages of java.lang

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/stdlib/BasicStdlibProvider.java
+++ b/core/src/main/java/com/nikodoko/javaimports/stdlib/BasicStdlibProvider.java
@@ -27,7 +27,9 @@ public class BasicStdlibProvider implements StdlibProvider {
     }
 
     for (Import match : matches) {
-      if (match.qualifier().startsWith("java.lang")) {
+      // We don't want to catch classes like java.lang.Thread.State, as those will need to be
+      // imported.
+      if (match.qualifier().equals("java.lang")) {
         return true;
       }
     }

--- a/core/src/test/java/com/nikodoko/javaimports/stdlib/BasicStdlibProviderTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/stdlib/BasicStdlibProviderTest.java
@@ -56,4 +56,9 @@ class BasicStdlibProviderTest {
   void testIdentifierIsNotInJavaLang() {
     assertThat(stdlib.isInJavaLang("List")).isFalse();
   }
+
+  @Test
+  void testIdentifierInSubScopeOfJavaLangIsNotConsideredInJavaLang() {
+    assertThat(stdlib.isInJavaLang("State")).isFalse();
+  }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/stdlib/FakeStdlib.java
+++ b/core/src/test/java/com/nikodoko/javaimports/stdlib/FakeStdlib.java
@@ -9,6 +9,11 @@ public class FakeStdlib implements Stdlib {
   private static final Map<String, Import[]> CLASSES =
       new ImmutableMap.Builder<String, Import[]>()
           .put(
+              "State",
+              new Import[] {
+                new Import("State", "java.lang.Thread", false),
+              })
+          .put(
               "Object",
               new Import[] {
                 new Import("Object", "java.lang", false),


### PR DESCRIPTION
* Classes in subpackages of `java.lang` (like `java.lang.Thread.State`) are now correctly imported.

Fixes #49 