### PR TITLE
Handle dependency type, scope and optional fields

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/common/Utils.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Utils.java
@@ -25,4 +25,8 @@ public class Utils {
   public static <T> ToStringHelper toStringHelper(T obj) {
     return new ToStringHelper(obj);
   }
+
+  public static void checkNotNull(Object o, String errorMsg) {
+    assert o != null : errorMsg;
+  }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/environment/maven/FlatPom.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/maven/FlatPom.java
@@ -44,7 +44,13 @@ class FlatPom {
                   }
 
                   var managedVersion = versionByManagedDependencies.get(d.hideVersion());
-                  return new MavenDependency(d.groupId(), d.artifactId(), managedVersion);
+                  return new MavenDependency(
+                      d.groupId(),
+                      d.artifactId(),
+                      managedVersion,
+                      d.type(),
+                      d.scope(),
+                      d.optional());
                 })
             .collect(Collectors.toList());
   }
@@ -65,7 +71,8 @@ class FlatPom {
 
   private MavenDependency substitutePropertyIfPossible(MavenDependency d) {
     var version = properties.getProperty(d.propertyReferencedByVersion(), d.version());
-    return new MavenDependency(d.groupId(), d.artifactId(), version);
+    return new MavenDependency(
+        d.groupId(), d.artifactId(), version, d.type(), d.scope(), d.optional());
   }
 
   /**

--- a/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenDependency.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenDependency.java
@@ -1,8 +1,8 @@
 package com.nikodoko.javaimports.environment.maven;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.nikodoko.javaimports.common.Utils.checkNotNull;
 
-import com.google.common.base.MoreObjects;
+import com.nikodoko.javaimports.common.Utils;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -36,12 +36,31 @@ class MavenDependency {
 
       var that = (Versionless) o;
       return Objects.equals(this.wrapped.groupId, that.wrapped.groupId)
+          && Objects.equals(this.wrapped.type, that.wrapped.type)
+          && Objects.equals(this.wrapped.scope, that.wrapped.scope)
+          && Objects.equals(this.wrapped.optional, that.wrapped.optional)
           && Objects.equals(this.wrapped.artifactId, that.wrapped.artifactId);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(this.wrapped.groupId, this.wrapped.artifactId);
+      return Objects.hash(
+          this.wrapped.groupId,
+          this.wrapped.artifactId,
+          this.wrapped.type,
+          this.wrapped.scope,
+          this.wrapped.optional);
+    }
+
+    @Override
+    public String toString() {
+      return Utils.toStringHelper(this)
+          .add("groupId", this.wrapped.groupId)
+          .add("artifactId", this.wrapped.artifactId)
+          .add("type", this.wrapped.type)
+          .add("scope", this.wrapped.scope)
+          .add("optional", this.wrapped.optional)
+          .toString();
     }
   }
 
@@ -95,17 +114,30 @@ class MavenDependency {
     }
   }
 
-  private static final Pattern parameterPattern = Pattern.compile("\\$\\{(?<parameter>\\S+)\\}");
   private final String groupId;
   private final String artifactId;
   private final Version version;
+  private final String type;
+  private final String scope;
+  private final boolean optional;
 
-  MavenDependency(String groupId, String artifactId, String version) {
+  MavenDependency(
+      String groupId,
+      String artifactId,
+      String version,
+      String type,
+      String scope,
+      boolean optional) {
     checkNotNull(groupId, "maven dependency does not accept a null groupId");
     checkNotNull(artifactId, "maven dependency does not accept a null artifactId");
+    checkNotNull(scope, "maven dependency does not accept a null scope");
+    checkNotNull(type, "maven dependency does not accept a null type");
     this.groupId = groupId;
     this.artifactId = artifactId;
     this.version = new Version(version);
+    this.type = type;
+    this.scope = scope;
+    this.optional = optional;
   }
 
   String version() {
@@ -118,6 +150,18 @@ class MavenDependency {
 
   String groupId() {
     return groupId;
+  }
+
+  String type() {
+    return type;
+  }
+
+  String scope() {
+    return scope;
+  }
+
+  boolean optional() {
+    return optional;
   }
 
   String propertyReferencedByVersion() {
@@ -150,6 +194,12 @@ class MavenDependency {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(
+        this.groupId, this.artifactId, this.version, this.type, this.scope, this.optional);
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (o == null) {
       return false;
@@ -162,15 +212,21 @@ class MavenDependency {
     MavenDependency d = (MavenDependency) o;
     return Objects.equals(d.groupId, groupId)
         && Objects.equals(d.artifactId, artifactId)
+        && Objects.equals(d.type, type)
+        && Objects.equals(d.scope, scope)
+        && Objects.equals(d.optional, optional)
         && Objects.equals(d.version, version);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
+    return Utils.toStringHelper(this)
         .add("groupId", groupId)
         .add("artifactId", artifactId)
         .add("version", version)
+        .add("type", type)
+        .add("scope", scope)
+        .add("optional", optional)
         .toString();
   }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenDependencyResolver.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenDependencyResolver.java
@@ -34,9 +34,10 @@ class MavenDependencyResolver {
 
   PrimaryArtifact resolve(MavenDependency dependency) throws IOException {
     var artifactPath = artifactPath(dependency);
+    var jarSuffix = dependency.type().equals("test-jar") ? "-tests.jar" : ".jar";
     return new PrimaryArtifact(
         artifactPath.resolveSibling(artifactPath.getFileName() + ".pom"),
-        artifactPath.resolveSibling(artifactPath.getFileName() + ".jar"));
+        artifactPath.resolveSibling(artifactPath.getFileName() + jarSuffix));
   }
 
   private Path artifactPath(MavenDependency dependency) throws IOException {

--- a/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenPomLoader.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenPomLoader.java
@@ -16,6 +16,8 @@ public class MavenPomLoader {
   // If <parent></parent> is present but no <relativePath> is specified then maven will default to
   // this relative path
   private static final Path DEFAULT_PARENT = Paths.get("../pom.xml");
+  private static final String DEFAULT_SCOPE = "compile";
+  private static final String DEFAULT_TYPE = "jar";
 
   static final class Result {
     final FlatPom pom;
@@ -91,7 +93,15 @@ public class MavenPomLoader {
 
   private static List<MavenDependency> convert(List<Dependency> dependencies) {
     return dependencies.stream()
-        .map(d -> new MavenDependency(d.getGroupId(), d.getArtifactId(), d.getVersion()))
+        .map(
+            d ->
+                new MavenDependency(
+                    d.getGroupId(),
+                    d.getArtifactId(),
+                    d.getVersion(),
+                    Optional.ofNullable(d.getType()).orElse(DEFAULT_TYPE),
+                    Optional.ofNullable(d.getScope()).orElse(DEFAULT_SCOPE),
+                    d.isOptional()))
         .collect(Collectors.toList());
   }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/environment/maven/FlatPomTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/environment/maven/FlatPomTest.java
@@ -9,12 +9,16 @@ import java.util.Properties;
 import org.junit.jupiter.api.Test;
 
 public class FlatPomTest {
+  static MavenDependency dependency(String groupId, String artifactId, String version) {
+    return new MavenDependency(groupId, artifactId, version, "jar", "compile", false);
+  }
+
   @Test
   void itPreservesDependenciesIfItHasNothingToEnrichThemWith() {
     var deps =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", null),
-            new MavenDependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
+            dependency("com.nikodoko", "javaimports", null),
+            dependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
 
     var pom = FlatPom.builder().dependencies(deps).build();
     assertThat(pom.dependencies()).containsExactlyElementsIn(deps);
@@ -25,16 +29,16 @@ public class FlatPomTest {
   void itGetsVersionFromManagedDependencyIfNeeded() {
     var deps =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", null),
-            new MavenDependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
+            dependency("com.nikodoko", "javaimports", null),
+            dependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
     var managedDeps =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", "${javaimports.version}"),
-            new MavenDependency("com.nikodoko", "javapackagetest", "1.0.0"));
+            dependency("com.nikodoko", "javaimports", "${javaimports.version}"),
+            dependency("com.nikodoko", "javapackagetest", "1.0.0"));
     var expected =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", "${javaimports.version}"),
-            new MavenDependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
+            dependency("com.nikodoko", "javaimports", "${javaimports.version}"),
+            dependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
 
     var pom = FlatPom.builder().dependencies(deps).managedDependencies(managedDeps).build();
     assertThat(pom.dependencies()).containsExactlyElementsIn(expected);
@@ -45,14 +49,14 @@ public class FlatPomTest {
   void itSubstitutesPropertiesIfNeeded() {
     var deps =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", "${javaimports.version}"),
-            new MavenDependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
+            dependency("com.nikodoko", "javaimports", "${javaimports.version}"),
+            dependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
     var properties = new Properties();
     properties.setProperty("javaimports.version", "2.0.0");
     var expected =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", "2.0.0"),
-            new MavenDependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
+            dependency("com.nikodoko", "javaimports", "2.0.0"),
+            dependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
 
     var pom = FlatPom.builder().dependencies(deps).properties(properties).build();
     assertThat(pom.dependencies()).containsExactlyElementsIn(expected);
@@ -63,17 +67,16 @@ public class FlatPomTest {
   void itCompletelyEnrichesDependenciesIfPossible() {
     var deps =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", null),
-            new MavenDependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
-    var managedDeps =
-        List.of(new MavenDependency("com.nikodoko", "javaimports", "${javaimports.version}"));
+            dependency("com.nikodoko", "javaimports", null),
+            dependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
+    var managedDeps = List.of(dependency("com.nikodoko", "javaimports", "${javaimports.version}"));
     var properties = new Properties();
     properties.setProperty("javaimports.version", "2.0.0");
     properties.setProperty("javapackagetest.version", "1.0.0");
     var expected =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", "2.0.0"),
-            new MavenDependency("com.nikodoko", "javapackagetest", "1.0.0"));
+            dependency("com.nikodoko", "javaimports", "2.0.0"),
+            dependency("com.nikodoko", "javapackagetest", "1.0.0"));
 
     var pom =
         FlatPom.builder()
@@ -89,28 +92,26 @@ public class FlatPomTest {
   void itDoesNothingWhenMergingIntoAWellDefinedPom() {
     var wellDefined =
         FlatPom.builder()
-            .dependencies(List.of(new MavenDependency("com.nikodoko", "javaimports", "1.0.0")))
+            .dependencies(List.of(dependency("com.nikodoko", "javaimports", "1.0.0")))
             .build();
     var other =
         FlatPom.builder()
-            .managedDependencies(
-                List.of(new MavenDependency("com.nikodoko", "javaimports", "2.0.0")))
+            .managedDependencies(List.of(dependency("com.nikodoko", "javaimports", "2.0.0")))
             .build();
 
     wellDefined.merge(other);
     assertThat(wellDefined.isWellDefined()).isTrue();
     assertThat(wellDefined.dependencies())
-        .containsExactly(new MavenDependency("com.nikodoko", "javaimports", "1.0.0"));
+        .containsExactly(dependency("com.nikodoko", "javaimports", "1.0.0"));
   }
 
   @Test
   void itMergesPomsInTheRightOrder() {
     var deps =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", null),
-            new MavenDependency("com.nikodoko", "javapackagetest", null));
-    var managedDeps =
-        List.of(new MavenDependency("com.nikodoko", "javaimports", "${javaimports.version}"));
+            dependency("com.nikodoko", "javaimports", null),
+            dependency("com.nikodoko", "javapackagetest", null));
+    var managedDeps = List.of(dependency("com.nikodoko", "javaimports", "${javaimports.version}"));
     var properties = new Properties();
     properties.setProperty("javapackagetest.version", "1.0.0");
     var firstPom =
@@ -123,16 +124,15 @@ public class FlatPomTest {
     assertThat(firstPom.isWellDefined()).isFalse();
 
     managedDeps =
-        List.of(
-            new MavenDependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
+        List.of(dependency("com.nikodoko", "javapackagetest", "${javapackagetest.version}"));
     properties = new Properties();
     properties.setProperty("javaimports.version", "2.0.0");
     var secondPom =
         FlatPom.builder().managedDependencies(managedDeps).properties(properties).build();
     var expected =
         List.of(
-            new MavenDependency("com.nikodoko", "javaimports", "2.0.0"),
-            new MavenDependency("com.nikodoko", "javapackagetest", "1.0.0"));
+            dependency("com.nikodoko", "javaimports", "2.0.0"),
+            dependency("com.nikodoko", "javapackagetest", "1.0.0"));
 
     firstPom.merge(secondPom);
     assertThat(firstPom.isWellDefined()).isTrue();
@@ -143,7 +143,7 @@ public class FlatPomTest {
   void itInheritsParentWhenMerging() {
     var firstPom =
         FlatPom.builder()
-            .dependencies(List.of(new MavenDependency("com.nikodoko", "javaimports", null)))
+            .dependencies(List.of(dependency("com.nikodoko", "javaimports", null)))
             .maybeParent(Optional.of(Paths.get("../pom.xml")))
             .build();
     var secondPom = FlatPom.builder().maybeParent(Optional.empty()).build();

--- a/core/src/test/java/com/nikodoko/javaimports/environment/maven/FlatPomTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/environment/maven/FlatPomTest.java
@@ -46,6 +46,17 @@ public class FlatPomTest {
   }
 
   @Test
+  void itSupportsDifferentDependenciesWithTheSameCoordinates() {
+    var managedDeps =
+        List.of(
+            new MavenDependency("com.nikodoko", "javaimports", "1.0.0", "jar", "compile", false),
+            new MavenDependency("com.nikodoko", "javaimports", "1.0.0", "jar", "test", false));
+    var pom = FlatPom.builder().managedDependencies(managedDeps).build();
+    assertThat(pom.dependencies()).isEmpty();
+    assertThat(pom.isWellDefined()).isTrue();
+  }
+
+  @Test
   void itSubstitutesPropertiesIfNeeded() {
     var deps =
         List.of(

--- a/core/src/test/java/com/nikodoko/javaimports/environment/maven/MavenDependencyResolverTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/environment/maven/MavenDependencyResolverTest.java
@@ -20,12 +20,12 @@ public class MavenDependencyResolverTest {
     return Stream.of(
         Arguments.of(
             "A dependency with a plain version is found",
-            new MavenDependency("com.mycompany.app", "a-dependency", "1.0"),
+            mavenDependency("com.mycompany.app", "a-dependency", "1.0"),
             "com/mycompany/app/a-dependency/1.0/a-dependency-1.0.jar",
             "com/mycompany/app/a-dependency/1.0/a-dependency-1.0.pom"),
         Arguments.of(
             "A dependency without plain version is resolved to the first available one",
-            new MavenDependency("com.mycompany.app", "a-dependency", null),
+            mavenDependency("com.mycompany.app", "a-dependency", null),
             "com/mycompany/app/a-dependency/1.0/a-dependency-1.0.jar",
             "com/mycompany/app/a-dependency/1.0/a-dependency-1.0.pom"));
   }
@@ -43,5 +43,9 @@ public class MavenDependencyResolverTest {
     var got = resolver.resolve(dependency);
     assertThat(got.jar).isEqualTo(repository.resolve(jarPath));
     assertThat(got.pom).isEqualTo(repository.resolve(pomPath));
+  }
+
+  static MavenDependency mavenDependency(String groupId, String artifactId, String version) {
+    return new MavenDependency(groupId, artifactId, version, "jar", "compile", false);
   }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/environment/maven/MavenDependencyResolverTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/environment/maven/MavenDependencyResolverTest.java
@@ -24,6 +24,12 @@ public class MavenDependencyResolverTest {
             "com/mycompany/app/a-dependency/1.0/a-dependency-1.0.jar",
             "com/mycompany/app/a-dependency/1.0/a-dependency-1.0.pom"),
         Arguments.of(
+            "A dependency with a test-jar type is found",
+            new MavenDependency(
+                "com.mycompany.app", "a-dependency", "1.0", "test-jar", "test", false),
+            "com/mycompany/app/a-dependency/1.0/a-dependency-1.0-tests.jar",
+            "com/mycompany/app/a-dependency/1.0/a-dependency-1.0.pom"),
+        Arguments.of(
             "A dependency without plain version is resolved to the first available one",
             mavenDependency("com.mycompany.app", "a-dependency", null),
             "com/mycompany/app/a-dependency/1.0/a-dependency-1.0.jar",

--- a/core/src/test/java/com/nikodoko/javaimports/environment/maven/MavenDependencyTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/environment/maven/MavenDependencyTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 public class MavenDependencyTest {
   @Test
   void testVersionlessEquals() {
-    var a = new MavenDependency("com.test", "dep", "12.0");
-    var b = new MavenDependency("com.test", "dep", "14.0");
+    var a = new MavenDependency("com.test", "dep", "12.0", "jar", "compile", false);
+    var b = new MavenDependency("com.test", "dep", "14.0", "jar", "compile", false);
     assertThat(a.hideVersion()).isEqualTo(b.hideVersion());
   }
 }


### PR DESCRIPTION
* Dependencies with a `<type>test-jar</type>` are now correctly resolved and the resulting test jar correctly scanned for imports.
* Fixed a bug where an error was thrown when two dependencies had the same coordinates (i.e. same `artifactId`, `groupId` and `version`) but a different `scope` or `type`.

Fixes #54 and #59.