### PR TITLE
Support reading from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Options:
     Print the version.
   --help, -help, -h
     Print this usage statement.
+
+File:
+  setting file equal to '-' will read from stdin
 ```
 
 ## Features

--- a/core/src/main/java/com/nikodoko/javaimports/cli/CLI.java
+++ b/core/src/main/java/com/nikodoko/javaimports/cli/CLI.java
@@ -8,7 +8,9 @@ import com.nikodoko.javaimports.Importer;
 import com.nikodoko.javaimports.ImporterException;
 import com.nikodoko.javaimports.Options;
 import com.nikodoko.javaimports.stdlib.StdlibProviders;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.file.Files;
@@ -80,6 +82,15 @@ public final class CLI {
     return code;
   }
 
+  private String readStdin() throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    String line = "", file = "";
+    while ((line = br.readLine()) != null) {
+      file = file + line + "\n";
+    }
+    return file;
+  }
+
   private int parse(String... args) throws UsageException {
     CLIOptions params = processArgs(args);
 
@@ -95,9 +106,15 @@ public final class CLI {
     Path path;
     String input;
     try {
-      // Importer expects an absolute path
-      path = Paths.get(params.file()).toAbsolutePath();
-      input = new String(Files.readAllBytes(path), UTF_8);
+      if (params.file().equals("-")) { // Read from Stdin
+        path = Paths.get("").toAbsolutePath(); // assumes current working directory
+        input = readStdin();
+      } else {
+        // Importer expects an absolute path
+        path = Paths.get(params.file()).toAbsolutePath();
+        input = new String(Files.readAllBytes(path), UTF_8);
+      }
+
     } catch (IOException e) {
       errWriter.println(params.file() + ": could not read file: " + e.getMessage());
       return 1;

--- a/core/src/main/java/com/nikodoko/javaimports/cli/CLIOptionsParser.java
+++ b/core/src/main/java/com/nikodoko/javaimports/cli/CLIOptionsParser.java
@@ -42,7 +42,7 @@ public class CLIOptionsParser {
     Iterator<String> it = args.iterator();
     while (it.hasNext()) {
       String option = it.next();
-      if (!option.startsWith("-")) {
+      if (!option.startsWith("-") || option.equals("-")) {
         optsBuilder.file(option);
         break;
       }

--- a/core/src/main/java/com/nikodoko/javaimports/cli/UsageException.java
+++ b/core/src/main/java/com/nikodoko/javaimports/cli/UsageException.java
@@ -22,6 +22,9 @@ public class UsageException extends Exception {
     "  --help, -help, -h",
     "    Print this usage statement.",
     "",
+    "File:",
+    "  setting file equal to '-' will read from stdin",
+    "",
   };
 
   public UsageException(String message) {


### PR DESCRIPTION
Formatting tools like [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports), [google-java-format](https://github.com/google/google-java-format) and [black](https://github.com/psf/black) all support reading files from `stdin`.

This PR adds the capability of reading a file from stdin to javaimports.

This solves issue #60 


# Usage:
to read from stdin pass '-' as the filename
```
java -jar javaimports.jar [options] -
```

# Possible problems

the file "path" in stdin-mode is assumed to be the current working directory. Not sure if that can be a problem for relative imports or something like that.