### PR TITLE
Support running the CLI with Java 17

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -121,9 +121,21 @@
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <!-- Include git hash in version to make it available from getImplementationVersion() -->
             <manifestEntries>
+              <!-- Include git hash in version to make it available from getImplementationVersion() -->
               <Implementation-Version>${project.version} (rev. ${git.commit.id.abbrev})</Implementation-Version>
+              <!-- These are to avoid having to provide them on the CLI when using java -jar -->
+              <Add-Exports><!--
+                -->jdk.compiler/com.sun.tools.javac.api <!--
+                -->jdk.compiler/com.sun.tools.javac.file <!--
+                -->jdk.compiler/com.sun.tools.javac.main <!--
+                -->jdk.compiler/com.sun.tools.javac.model <!--
+                -->jdk.compiler/com.sun.tools.javac.parser <!--
+                -->jdk.compiler/com.sun.tools.javac.processing <!--
+                -->jdk.compiler/com.sun.tools.javac.tree <!--
+                -->jdk.compiler/com.sun.tools.javac.util<!--
+              --></Add-Exports>
+              <Add-Opens>jdk.compiler/com.sun.tools.javac.code jdk.compiler/com.sun.tools.javac.comp</Add-Opens>
             </manifestEntries>
             <manifest>
               <mainClass>com.nikodoko.javaimports.cli.CLI</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,14 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M4</version>
+          <configuration>
+            <argLine>
+              --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+              --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+              --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+              --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+            </argLine>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
-    <guava.version>28.1-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <truth.version>1.0.1</truth.version>
-    <googlejavaformat.version>1.9</googlejavaformat.version>
+    <googlejavaformat.version>1.15.0</googlejavaformat.version>
     <junit5.version>5.6.2</junit5.version>
     <jqwik.version>1.3.1</jqwik.version>
     <javapackagetest.version>1.0</javapackagetest.version>
@@ -183,12 +183,9 @@
           </links>
           <additionalJOptions>
             <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED,com.google.googlejavaformat</additionalJOption>
-            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED,com.google.googlejavaformat</additionalJOption>
             <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED,com.google.googlejavaformat</additionalJOption>
             <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED,com.google.googlejavaformat</additionalJOption>
             <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED,com.google.googlejavaformat</additionalJOption>
-            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED,com.google.googlejavaformat</additionalJOption>
-            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED,com.google.googlejavaformat</additionalJOption>
           </additionalJOptions>
         </configuration>
         <executions>


### PR DESCRIPTION
* Fixed issues when running `javaimports` using `java -jar` with Java 17, it is now possible to use `javaimports` on files using java 17 features such as `record`.