### PR TITLE
Rework class hierarchy

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Selector.java
@@ -166,6 +166,28 @@ public final class Selector {
     return new Selector(List.copyOf(identifiers.subList(0, cutoff)));
   }
 
+  /**
+   * Constructs a new {@code Selector} by rebasing this selector on a {@code base}.
+   *
+   * <p>This requires that this selector {@link #startsWith} {@code base}, and will trim {@code
+   * base} off this selector. It will fail if {@code base.equals(this)} is {@code true}.
+   *
+   * <p>For example, if this selector represents {@code "a.b.c.d"}, then invoking this method with a
+   * selector representing {@code a.b} will return a selector representing {@code "c.d"}.
+   *
+   * @param base the selector to rebase this selector on
+   * @return the resulting selector
+   * @exception IllegalArgumentException if this selector does not start with {@code base}, or if
+   *     {@code base} is equal to this selector
+   */
+  public Selector rebase(Selector base) {
+    if (!startsWith(base) || equals(base)) {
+      throw new IllegalArgumentException(String.format("Cannot rebase %s on %s", this, base));
+    }
+
+    return new Selector(List.copyOf(identifiers.subList(base.size(), identifiers.size())));
+  }
+
   /** Returns true if this {@code Selector} ends with {@code other}. */
   public boolean endsWith(Selector other) {
     var thisLength = identifiers.size();

--- a/core/src/main/java/com/nikodoko/javaimports/common/Utils.java
+++ b/core/src/main/java/com/nikodoko/javaimports/common/Utils.java
@@ -29,4 +29,8 @@ public class Utils {
   public static void checkNotNull(Object o, String errorMsg) {
     assert o != null : errorMsg;
   }
+
+  public static void checkNotNull(Object o) {
+    assert o != null;
+  }
 }

--- a/core/src/main/java/com/nikodoko/javaimports/parser/ClassTree.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/ClassTree.java
@@ -1,0 +1,122 @@
+package com.nikodoko.javaimports.parser;
+
+import static com.nikodoko.javaimports.common.Utils.checkNotNull;
+
+import com.nikodoko.javaimports.common.ClassEntity;
+import com.nikodoko.javaimports.common.Identifier;
+import com.nikodoko.javaimports.common.Selector;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A tree view of Java classes.
+ *
+ * <p>Leaves are non class Java objects that can contain classes (like functions). Leaves have a
+ * parent, but are not added to this parent's childs, effectively forming an orphan tree containing
+ * classes not reachable from the parent and above.
+ */
+public class ClassTree {
+  // Used to represent anything that can have nested classes, but is not a class (and therefore
+  // invisible from the outside)
+  private static final ClassEntity NOT_A_CLASS =
+      ClassEntity.named(Selector.of("NOT_A_CLASS")).build();
+
+  private ClassEntity entity;
+  private final ClassTree parent;
+  // We want values to be presented in order of insertion
+  private final LinkedList<ClassTree> childs;
+
+  private ClassTree(ClassTree parent, ClassEntity entity) {
+    checkNotNull(entity);
+    this.entity = entity;
+    this.parent = parent;
+    this.childs = new LinkedList<>();
+  }
+
+  static ClassTree root(ClassEntity entity) {
+    return new ClassTree(null, entity);
+  }
+
+  static ClassTree notAClass(ClassTree parent) {
+    return new ClassTree(parent, NOT_A_CLASS);
+  }
+
+  public Optional<ClassEntity> find(Selector selector) {
+    var maybeCandidate =
+        childs.stream().filter(n -> selector.startsWith(n.entity.name)).findFirst();
+
+    if (maybeCandidate.isEmpty()) {
+      if (entity.name.equals(selector)) {
+        return Optional.of(entity);
+      }
+
+      return Optional.empty();
+    }
+
+    var candidate = maybeCandidate.get();
+    if (candidate.entity.name.equals(selector)) {
+      return Optional.of(candidate.entity);
+    }
+
+    return candidate.find(selector.rebase(candidate.entity.name));
+  }
+
+  public ClassTree pushAndMoveDown(ClassEntity child) {
+    var next = new ClassTree(this, child);
+    childs.add(next);
+    return next;
+  }
+
+  public ClassTree moveDown() {
+    return notAClass(this);
+  }
+
+  public ClassTree moveUp() {
+    if (parent == null) {
+      throw new IllegalStateException("Cannot move up, currently at root");
+    }
+
+    return parent;
+  }
+
+  // Workaround the fact that ClassEntity is immutable
+  public void addDeclarations(Set<Identifier> declarations) {
+    var allDeclarations =
+        Stream.concat(declarations.stream(), entity.declarations.stream())
+            .collect(Collectors.toSet());
+    var updated = ClassEntity.named(entity.name).declaring(allDeclarations);
+    if (entity.maybeParent.isPresent()) {
+      updated.extending(entity.maybeParent.get());
+    }
+
+    entity = updated.build();
+  }
+
+  /**
+   * Returns a map of {@code selector:entity} such that if the entity of this node is in a package
+   * {@code pkg}, {@code pkg.combine(selector)} gives the import path to {@code entity}.
+   */
+  public Map<Selector, ClassEntity> flatView() {
+    return flatten(Optional.empty());
+  }
+
+  private Map<Selector, ClassEntity> flatten(Optional<Selector> maybeScope) {
+    if (entity == NOT_A_CLASS) {
+      return Map.of();
+    }
+
+    var flattenedView = new HashMap<Selector, ClassEntity>();
+    var scope = maybeScope.map(s -> s.combine(entity.name)).orElse(entity.name);
+    flattenedView.put(scope, entity);
+    for (var child : childs) {
+      flattenedView.putAll(child.flatten(Optional.of(scope)));
+    }
+
+    return flattenedView;
+  }
+}

--- a/core/src/main/java/com/nikodoko/javaimports/parser/ParsedFile.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/ParsedFile.java
@@ -163,10 +163,7 @@ public class ParsedFile implements ImportProvider, ClassProvider {
     return topScope.identifiers;
   }
 
-  public ClassHierarchy classHierarchy() {
-    return classHierarchy;
-  }
-
+  // Used only for tests
   public Stream<ClassEntity> classes() {
     return ClassHierarchies.flatView(classHierarchy);
   }

--- a/core/src/main/java/com/nikodoko/javaimports/parser/ParsedFile.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/ParsedFile.java
@@ -2,11 +2,11 @@ package com.nikodoko.javaimports.parser;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Range;
+import com.nikodoko.javaimports.common.ClassEntity;
 import com.nikodoko.javaimports.common.ClassProvider;
 import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.common.ImportProvider;
 import com.nikodoko.javaimports.common.Selector;
-import com.nikodoko.javaimports.parser.internal.ClassEntity;
 import com.nikodoko.javaimports.parser.internal.Scope;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
@@ -35,7 +35,7 @@ public class ParsedFile implements ImportProvider, ClassProvider {
   // The position of the end of the package clause
   int packageEndPos;
   List<Range<Integer>> duplicates;
-  Map<com.nikodoko.javaimports.common.Import, com.nikodoko.javaimports.common.ClassEntity> classes;
+  Map<com.nikodoko.javaimports.common.Import, ClassEntity> classes;
 
   /**
    * A {@code ParsedFile} constructor.
@@ -145,8 +145,7 @@ public class ParsedFile implements ImportProvider, ClassProvider {
   }
 
   @Override
-  public Optional<com.nikodoko.javaimports.common.ClassEntity> findClass(
-      com.nikodoko.javaimports.common.Import i) {
+  public Optional<ClassEntity> findClass(com.nikodoko.javaimports.common.Import i) {
     // System.out.println(String.format("Looking for %s in %s", i, byImport));
     return Optional.ofNullable(classes.get(i));
   }
@@ -165,7 +164,8 @@ public class ParsedFile implements ImportProvider, ClassProvider {
 
   // Used only for tests
   public Stream<ClassEntity> classes() {
-    return ClassHierarchies.flatView(classHierarchy);
+    return ClassHierarchies.flatView(classHierarchy)
+        .map(com.nikodoko.javaimports.parser.internal.ClassEntity::toNew);
   }
 
   // TODO: maybe have a SiblingFile with the below findImports, and make this the default

--- a/core/src/main/java/com/nikodoko/javaimports/parser/Parser.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/Parser.java
@@ -83,12 +83,16 @@ public class Parser {
 
     // Scan the AST
     UnresolvedIdentifierScanner scanner = new UnresolvedIdentifierScanner();
-    scanner.scan(unit, null);
+    try {
+      scanner.scan(unit, null);
+    } catch (Exception e) {
+      throw new RuntimeException("Could not parse file at " + filename, e);
+    }
 
     // Wrap the results in a ParsedFile
     ParsedFile f = ParsedFile.fromCompilationUnit(unit);
     f.topScope(scanner.topScope());
-    f.classHierarchy(scanner.topClass());
+    f.classTree(scanner.classTree());
     if (options.debug()) {
       log.info(String.format("completed parsing in %d ms: %s", clock.millis() - start, f));
     }

--- a/core/src/main/java/com/nikodoko/javaimports/parser/internal/Scope.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/internal/Scope.java
@@ -1,6 +1,7 @@
 package com.nikodoko.javaimports.parser.internal;
 
 import com.google.common.base.MoreObjects;
+import com.nikodoko.javaimports.common.OrphanClass;
 import com.nikodoko.javaimports.parser.ClassExtender;
 import java.util.HashSet;
 import java.util.Set;
@@ -19,6 +20,7 @@ public class Scope {
   // Parent scope can be null if top scope
   public Scope parent = null;
   public Set<ClassExtender> notFullyExtended = new HashSet<>();
+  public Set<OrphanClass> orphans = new HashSet<>();
 
   /**
    * Debugging support.

--- a/core/src/test/java/com/nikodoko/javaimports/ImporterIntegrationTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/ImporterIntegrationTest.java
@@ -84,6 +84,8 @@ public class ImporterIntegrationTest {
         System.out.println(d);
       }
       fail();
+    } catch (Exception e) {
+      fail("Got exception for " + pkg.name + ": " + e);
     }
   }
 

--- a/core/src/test/java/com/nikodoko/javaimports/common/SelectorTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/common/SelectorTest.java
@@ -2,6 +2,7 @@ package com.nikodoko.javaimports.common;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import net.jqwik.api.Arbitrary;
@@ -54,6 +55,37 @@ public class SelectorTest {
 
     assertThat(aSelector).isEqualTo(Selector.of(identifiersCopy));
     assertThat(aSelectorTail).isEqualTo(Selector.of(tailCopy));
+  }
+
+  @Property
+  void rebaseLeavesOriginalSelectorsUnchanged(
+      @ForAll("identifiers") List<String> base, @ForAll("identifiers") List<String> tail) {
+    var combined = new ArrayList<>(List.copyOf(base));
+    combined.addAll(tail);
+    var combinedCopy = List.copyOf(combined);
+    var baseCopy = List.copyOf(base);
+
+    var aSelector = Selector.of(combined);
+    var aBase = Selector.of(base);
+
+    aSelector.rebase(aBase);
+
+    assertThat(aSelector).isEqualTo(Selector.of(combinedCopy));
+    assertThat(aBase).isEqualTo(Selector.of(baseCopy));
+  }
+
+  @Property
+  void rebaseTrimsTheBase(
+      @ForAll("identifiers") List<String> base, @ForAll("identifiers") List<String> tail) {
+    var combined = new ArrayList<>(List.copyOf(base));
+    combined.addAll(tail);
+
+    var aSelector = Selector.of(combined);
+    var aBase = Selector.of(base);
+
+    var got = aSelector.rebase(aBase);
+
+    assertThat(got).isEqualTo(Selector.of(tail));
   }
 
   @Example

--- a/core/src/test/java/com/nikodoko/javaimports/parser/ClassTreeTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/parser/ClassTreeTest.java
@@ -1,0 +1,87 @@
+package com.nikodoko.javaimports.parser;
+
+import static com.google.common.truth.Truth8.assertThat;
+
+import com.nikodoko.javaimports.common.ClassEntity;
+import com.nikodoko.javaimports.common.Selector;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ClassTreeTest {
+  // by nikodoko.com
+  static final ClassEntity ROOT = ClassEntity.named(Selector.of("Root")).build();
+  static final ClassEntity A = ClassEntity.named(Selector.of("A")).build();
+  static final ClassEntity B = ClassEntity.named(Selector.of("B")).build();
+  static final ClassEntity C = ClassEntity.named(Selector.of("C")).build();
+  static final ClassEntity D1 = ClassEntity.named(Selector.of("D1")).build();
+  static final ClassEntity D2 = ClassEntity.named(Selector.of("D2")).build();
+  static ClassTree root;
+  static ClassTree functionRoot;
+
+  // Create the following:
+  // root
+  // |
+  // - A
+  // | |
+  // | - B
+  // |
+  // - C
+  //   |
+  //   - functionRoot (i.e. a function declaring local classes)
+  //     |
+  //     - C1
+  //     - C2
+  @BeforeAll
+  static void setupTree() {
+    var tree = ClassTree.root(ROOT);
+    root = tree;
+    tree = tree.pushAndMoveDown(A);
+    tree = tree.pushAndMoveDown(B);
+    tree = tree.moveUp();
+    tree = tree.moveUp();
+    tree = tree.pushAndMoveDown(C);
+    tree = tree.moveDown();
+    functionRoot = tree;
+    tree = tree.pushAndMoveDown(D1);
+    tree = tree.moveUp();
+    tree = tree.pushAndMoveDown(D2);
+  }
+
+  @Test
+  void testFound() {
+    assertThat(root.find(Selector.of("A"))).hasValue(A);
+    assertThat(root.find(Selector.of("A", "B"))).hasValue(B);
+    assertThat(root.find(Selector.of("C"))).hasValue(C);
+    assertThat(root.find(Selector.of("Root"))).hasValue(ROOT);
+  }
+
+  @Test
+  void testNotFound() {
+    assertThat(root.find(Selector.of("Z"))).isEmpty();
+  }
+
+  @Test
+  void testClassesInFunctionRootNotReachableFromParent() {
+    assertThat(root.find(Selector.of("C", "D1"))).isEmpty();
+    assertThat(root.find(Selector.of("C", "D2"))).isEmpty();
+  }
+
+  @Test
+  void testFunctionRootChildsCanReachEachother() {
+    assertThat(functionRoot.find(Selector.of("D1"))).hasValue(D1);
+    assertThat(functionRoot.find(Selector.of("D2"))).hasValue(D2);
+  }
+
+  @Test
+  void testFlatView() {
+    var got = root.flatView();
+    com.google.common.truth.Truth.assertThat(got)
+        .isEqualTo(
+            Map.of(
+                Selector.of("Root"), ROOT,
+                Selector.of("Root", "A"), A,
+                Selector.of("Root", "A", "B"), B,
+                Selector.of("Root", "C"), C));
+  }
+}

--- a/core/src/test/java/com/nikodoko/javaimports/parser/ClassTreeTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/parser/ClassTreeTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 public class ClassTreeTest {
   // by nikodoko.com
-  static final ClassEntity ROOT = ClassEntity.named(Selector.of("Root")).build();
   static final ClassEntity A = ClassEntity.named(Selector.of("A")).build();
   static final ClassEntity B = ClassEntity.named(Selector.of("B")).build();
   static final ClassEntity C = ClassEntity.named(Selector.of("C")).build();
@@ -30,11 +29,11 @@ public class ClassTreeTest {
   //   |
   //   - functionRoot (i.e. a function declaring local classes)
   //     |
-  //     - C1
-  //     - C2
+  //     - D1
+  //     - D2
   @BeforeAll
   static void setupTree() {
-    var tree = ClassTree.root(ROOT);
+    var tree = ClassTree.root();
     root = tree;
     tree = tree.pushAndMoveDown(A);
     tree = tree.pushAndMoveDown(B);
@@ -53,7 +52,6 @@ public class ClassTreeTest {
     assertThat(root.find(Selector.of("A"))).hasValue(A);
     assertThat(root.find(Selector.of("A", "B"))).hasValue(B);
     assertThat(root.find(Selector.of("C"))).hasValue(C);
-    assertThat(root.find(Selector.of("Root"))).hasValue(ROOT);
   }
 
   @Test
@@ -79,9 +77,11 @@ public class ClassTreeTest {
     com.google.common.truth.Truth.assertThat(got)
         .isEqualTo(
             Map.of(
-                Selector.of("Root"), ROOT,
-                Selector.of("Root", "A"), A,
-                Selector.of("Root", "A", "B"), B,
-                Selector.of("Root", "C"), C));
+                Selector.of("A"), A,
+                Selector.of("A", "B"), B,
+                Selector.of("C"), C));
+
+    got = functionRoot.flatView();
+    com.google.common.truth.Truth.assertThat(got).isEmpty();
   }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/parser/ParserTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/parser/ParserTest.java
@@ -22,6 +22,35 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class ParserTest {
   static Object[][][] CASES = {
     {
+      {"multipleTopLevelClassesInSameFile"},
+      {
+        "package com.pkg.test;",
+        "class ATest {",
+        "  public void g() {",
+        "    int c = f(b);",
+        "  }",
+        "  public int f(int a) {",
+        "    int b = 2;",
+        "    return a + b;",
+        "  }",
+        "}",
+        "class AnotherTest {",
+        "  public void g() {",
+        "    int c = f(d);",
+        "  }",
+        "  public int f(int a) {",
+        "    int b = 2;",
+        "    return a + b;",
+        "  }",
+        "}",
+      },
+      {"b", "d"},
+      {
+        ClassEntity.named(aSelector("ATest")).declaring(someIdentifiers("g", "f")).build(),
+        ClassEntity.named(aSelector("AnotherTest")).declaring(someIdentifiers("g", "f")).build()
+      },
+    },
+    {
       {"methodBodyAndArguments"},
       {
         "package com.pkg.test;",
@@ -1217,9 +1246,7 @@ public class ParserTest {
 
     assertThat(allUnresolvedIn(got)).containsExactlyElementsIn(expected);
     if (expectedClasses.length > 0) {
-      com.google.common.truth.Truth8.assertThat(got.classes())
-          .containsExactly(expectedClasses)
-          .inOrder();
+      com.google.common.truth.Truth8.assertThat(got.classes()).containsExactly(expectedClasses);
     }
   }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/parser/ParserTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/parser/ParserTest.java
@@ -1,15 +1,16 @@
 package com.nikodoko.javaimports.parser;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.nikodoko.javaimports.common.CommonTestUtil.aSelector;
+import static com.nikodoko.javaimports.common.CommonTestUtil.someIdentifiers;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.nikodoko.javaimports.ImporterException;
 import com.nikodoko.javaimports.Options;
-import com.nikodoko.javaimports.parser.internal.ClassEntity;
-import com.nikodoko.javaimports.parser.internal.ClassSelectors;
+import com.nikodoko.javaimports.common.ClassEntity;
+import com.nikodoko.javaimports.common.Superclass;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Set;
@@ -35,7 +36,7 @@ public class ParserTest {
         "}",
       },
       {"b"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("g", "f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("g", "f")).build()},
     },
     {
       {"forLoop"},
@@ -57,7 +58,7 @@ public class ParserTest {
         "}",
       },
       {"staticFunction", "i", "b", "e", "d"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"ifBlock"},
@@ -76,7 +77,7 @@ public class ParserTest {
         "}",
       },
       {"a", "b", "c"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"whileLoop"},
@@ -92,7 +93,7 @@ public class ParserTest {
         "}",
       },
       {"a"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"synchronizedBlock"},
@@ -109,7 +110,7 @@ public class ParserTest {
       },
       // The parser does not know about "this" and sees it as an unresolved symbol
       {"this", "a"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"doWhileLoop"},
@@ -125,7 +126,7 @@ public class ParserTest {
         "}",
       },
       {"a"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"annotation"},
@@ -139,7 +140,7 @@ public class ParserTest {
         "}",
       },
       {"SomeAnnotation"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"lambda"},
@@ -154,7 +155,7 @@ public class ParserTest {
         "}",
       },
       {"b", "Integer", "BiFunction"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"switchBlock"},
@@ -176,7 +177,7 @@ public class ParserTest {
         "}",
       },
       {"c"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"java14Switch"},
@@ -200,7 +201,7 @@ public class ParserTest {
         "}",
       },
       {"c"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       // Because "The scope of an enum constant C declared in an enum type T is the body of T, and
@@ -221,7 +222,7 @@ public class ParserTest {
         "}",
       },
       {"a"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"java14SwitchIgnoreCaseLabels"},
@@ -240,7 +241,7 @@ public class ParserTest {
         "}",
       },
       {"a"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"tryCatchFinally"},
@@ -262,7 +263,7 @@ public class ParserTest {
         "}",
       },
       {"SomeException", "Exception", "a", "b", "c", "e"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"tryWithResource"},
@@ -284,7 +285,7 @@ public class ParserTest {
         "}",
       },
       {"SomeException", "Exception", "a", "b", "c", "e", "r"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"localInheritence"},
@@ -318,12 +319,20 @@ public class ParserTest {
       },
       {"b", "n"},
       {
-        ClassEntity.named("Test").members(ImmutableSet.of("OtherChild", "Child", "Parent")),
-        ClassEntity.namedAndExtending("OtherChild", ClassSelectors.of("Child"))
-            .members(ImmutableSet.of("m")),
-        ClassEntity.namedAndExtending("Child", ClassSelectors.of("Parent"))
-            .members(ImmutableSet.of("f")),
-        ClassEntity.named("Parent").members(ImmutableSet.of("a", "p", "g", "h"))
+        ClassEntity.named(aSelector("Test"))
+            .declaring(someIdentifiers("OtherChild", "Child", "Parent"))
+            .build(),
+        ClassEntity.named(aSelector("OtherChild"))
+            .extending(Superclass.unresolved(aSelector("Child")))
+            .declaring(someIdentifiers("m"))
+            .build(),
+        ClassEntity.named(aSelector("Child"))
+            .extending(Superclass.unresolved(aSelector("Parent")))
+            .declaring(someIdentifiers("f"))
+            .build(),
+        ClassEntity.named(aSelector("Parent"))
+            .declaring(someIdentifiers("a", "p", "g", "h"))
+            .build()
       },
     },
     {
@@ -339,7 +348,7 @@ public class ParserTest {
         "}",
       },
       {"Annotation", "Function"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"annotationParametersExpressionImported"},
@@ -354,7 +363,7 @@ public class ParserTest {
         "}",
       },
       {"Annotation", "Function", "b", "d"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"annotationParametersIdentifierImported"},
@@ -369,7 +378,7 @@ public class ParserTest {
         "}",
       },
       {"Annotation", "Function", "b"},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f")).build()},
     },
     {
       {"typeParameters"},
@@ -383,7 +392,7 @@ public class ParserTest {
         "}",
       },
       {},
-      {ClassEntity.named("Test").members(ImmutableSet.of("f", "R"))},
+      {ClassEntity.named(aSelector("Test")).declaring(someIdentifiers("f", "R")).build()},
     },
     {
       {"realisticFile"},
@@ -1060,9 +1069,10 @@ public class ParserTest {
         "SafeVarargs",
       },
       {
-        ClassEntity.namedAndExtending("ImmutableSet", ClassSelectors.of("ImmutableCollection"))
-            .members(
-                ImmutableSet.of(
+        ClassEntity.named(aSelector("ImmutableSet"))
+            .extending(Superclass.unresolved(aSelector("ImmutableCollection")))
+            .declaring(
+                someIdentifiers(
                     "Builder",
                     "E",
                     "Indexed",
@@ -1095,23 +1105,27 @@ public class ParserTest {
                     "HASH_FLOODING_FPP",
                     "MAX_RUN_MULTIPLIER",
                     "hashFloodingDetected",
-                    "maxRunBeforeFallback")),
-        ClassEntity.namedAndExtending("Indexed", ClassSelectors.of("ImmutableSet"))
-            .members(
-                ImmutableSet.of(
+                    "maxRunBeforeFallback"))
+            .build(),
+        ClassEntity.named(aSelector("Indexed"))
+            .extending(Superclass.unresolved(aSelector("ImmutableSet")))
+            .declaring(
+                someIdentifiers(
                     "E",
                     "get",
                     "iterator",
                     "spliterator",
                     "forEach",
                     "copyIntoArray",
-                    "createAsList")),
-        ClassEntity.named("SerializedForm")
-            .members(ImmutableSet.of("<init>", "elements", "readResolve", "serialVersionUID")),
-        ClassEntity.namedAndExtending(
-                "Builder", ClassSelectors.of("ImmutableCollection", "Builder"))
-            .members(
-                ImmutableSet.of(
+                    "createAsList"))
+            .build(),
+        ClassEntity.named(aSelector("SerializedForm"))
+            .declaring(someIdentifiers("<init>", "elements", "readResolve", "serialVersionUID"))
+            .build(),
+        ClassEntity.named(aSelector("Builder"))
+            .extending(Superclass.unresolved(aSelector("ImmutableCollection.Builder")))
+            .declaring(
+                someIdentifiers(
                     "<init>",
                     "E",
                     "impl",
@@ -1122,10 +1136,11 @@ public class ParserTest {
                     "add",
                     "addAll",
                     "combine",
-                    "build")),
-        ClassEntity.named("SetBuilderImpl")
-            .members(
-                ImmutableSet.of(
+                    "build"))
+            .build(),
+        ClassEntity.named(aSelector("SetBuilderImpl"))
+            .declaring(
+                someIdentifiers(
                     "<init>",
                     "E",
                     "dedupedElements",
@@ -1136,10 +1151,12 @@ public class ParserTest {
                     "combine",
                     "copy",
                     "review",
-                    "build")),
-        ClassEntity.namedAndExtending("RegularSetBuilderImpl", ClassSelectors.of("SetBuilderImpl"))
-            .members(
-                ImmutableSet.of(
+                    "build"))
+            .build(),
+        ClassEntity.named(aSelector("RegularSetBuilderImpl"))
+            .extending(Superclass.unresolved(aSelector("SetBuilderImpl")))
+            .declaring(
+                someIdentifiers(
                     "<init>",
                     "E",
                     "hashTable",
@@ -1150,10 +1167,12 @@ public class ParserTest {
                     "add",
                     "copy",
                     "review",
-                    "build")),
-        ClassEntity.namedAndExtending(
-                "JdkBackedSetBuilderImpl", ClassSelectors.of("SetBuilderImpl"))
-            .members(ImmutableSet.of("<init>", "E", "delegate", "add", "copy", "build"))
+                    "build"))
+            .build(),
+        ClassEntity.named(aSelector("JdkBackedSetBuilderImpl"))
+            .extending(Superclass.unresolved(aSelector("SetBuilderImpl")))
+            .declaring(someIdentifiers("<init>", "E", "delegate", "add", "copy", "build"))
+            .build()
       },
     },
   };


### PR DESCRIPTION
First part of refactor to remove old `parser.internal` classes from the codebase.