### PR TITLE
Handle parent classes provided by parent of outer class

### DIFF
--- a/core/src/test/java/com/nikodoko/javaimports/common/CommonTestUtil.java
+++ b/core/src/test/java/com/nikodoko/javaimports/common/CommonTestUtil.java
@@ -2,6 +2,7 @@ package com.nikodoko.javaimports.common;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import net.jqwik.api.Arbitraries;
@@ -54,5 +55,18 @@ public class CommonTestUtil {
 
   public static Set<Identifier> someIdentifiers(String... identifiers) {
     return Arrays.stream(identifiers).map(Identifier::new).collect(Collectors.toSet());
+  }
+
+  public static ClassDeclaration aClassDecl(String classDecl) {
+    var elts = classDecl.split(" extends ");
+    if (elts.length == 1) {
+      return new ClassDeclaration(aSelector(elts[0]), Optional.empty());
+    }
+
+    if (elts.length == 2) {
+      return new ClassDeclaration(aSelector(elts[0]), Superclass.unresolved(aSelector(elts[1])));
+    }
+
+    throw new IllegalArgumentException("invalid class declaration: " + classDecl);
   }
 }

--- a/core/src/test/java/com/nikodoko/javaimports/fixer/ParentClassFinderTest.java
+++ b/core/src/test/java/com/nikodoko/javaimports/fixer/ParentClassFinderTest.java
@@ -7,6 +7,7 @@ import com.nikodoko.javaimports.Options;
 import com.nikodoko.javaimports.common.ClassDeclaration;
 import com.nikodoko.javaimports.common.ClassEntity;
 import com.nikodoko.javaimports.common.Identifier;
+import com.nikodoko.javaimports.common.Import;
 import com.nikodoko.javaimports.common.Selector;
 import com.nikodoko.javaimports.common.Superclass;
 import com.nikodoko.javaimports.fixer.candidates.Candidate;
@@ -66,7 +67,7 @@ public class ParentClassFinderTest {
       }
 
       @Override
-      public void addParent(ClassEntity entity) {
+      public void addParent(Import parentImport, ClassEntity entity) {
         entity.declarations.forEach(unresolved::remove);
         parent = entity.maybeParent;
       }

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/nestedOrphansWithNestedParents/nestedOrphansWithNestedParents.input
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/nestedOrphansWithNestedParents/nestedOrphansWithNestedParents.input
@@ -1,0 +1,7 @@
+package nestedOrphansWithNestedParents;
+
+// Test that an inner class extending a class that is declared inside the parent of the 
+// enclosing class does not result in unecessary import lines
+class Test extends Parent {
+  class Nested extends AnotherPublicClass {} 
+}

--- a/core/src/test/resources/com/nikodoko/javaimports/testdata/nestedOrphansWithNestedParents/nestedOrphansWithNestedParents.output
+++ b/core/src/test/resources/com/nikodoko/javaimports/testdata/nestedOrphansWithNestedParents/nestedOrphansWithNestedParents.output
@@ -1,0 +1,7 @@
+package nestedOrphansWithNestedParents;import com.mycompany.app.another.Parent;
+
+// Test that an inner class extending a class that is declared inside the parent of the 
+// enclosing class does not result in unecessary import lines
+class Test extends Parent {
+  class Nested extends AnotherPublicClass {} 
+}


### PR DESCRIPTION
* Fixed a bug where an import line would be added for an `extends` clause when it is not necessary, because it is provided by the parent of an outer class.