### PR TITLE
Do not fail if the parent pom is itself a child pom with a relative parent

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenDependencyFinder.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenDependencyFinder.java
@@ -44,12 +44,14 @@ class MavenDependencyFinder {
 
     var pom = loaded.pom;
     var errors = new ArrayList<>(loaded.errors);
+    var currentPomDir = moduleRoot;
     while (hasRelativeParentPath(pom)) {
       // We need to normalize because the relative parent path often includes the special name ..
-      var parentPath = moduleRoot.resolve(relativeParentPomPath(pom)).normalize();
+      var parentPath = currentPomDir.resolve(relativeParentPomPath(pom)).normalize();
       loaded = MavenPomLoader.load(parentPath);
       errors.addAll(loaded.errors);
       pom.merge(loaded.pom);
+      currentPomDir = parentPath.getParent();
     }
 
     // According to the maven documentation, managed dependencies with scope "import" should be


### PR DESCRIPTION
* Fixed a bug where a parent pom having itself a parent pom indicated with a relative path could result in a deadlock.