### PR TITLE
Consider an extends clause starting with lower case as resolved

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/parser/internal/ClassMap.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/internal/ClassMap.java
@@ -5,6 +5,7 @@ import com.nikodoko.javaimports.common.Import;
 import com.nikodoko.javaimports.common.Selector;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Traverse a {@link Scope} tree and extracts the reachable {@link ClassEntity} along with their
@@ -30,7 +31,7 @@ public class ClassMap {
     var entity =
         ClassEntity.named(decl.name())
             .extending(decl.maybeParent())
-            .declaring(scope.declarations)
+            .declaring(Set.copyOf(scope.declarations))
             .build();
     result.put(i, entity);
 

--- a/core/src/main/java/com/nikodoko/javaimports/parser/internal/JCHelper.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/internal/JCHelper.java
@@ -20,6 +20,14 @@ import java.util.List;
 public class JCHelper {
   static Superclass toSuperclass(JCExpression extendsClause) {
     var selector = toSelector(extendsClause);
+    // Hack: sometimes, the extend clause can represent a resolved superclass
+    // We cannot know it for sure at this stage, but what we can do is assume that if the selector
+    // does not start with a capital letter, then it starts with a package name and is therefore
+    // resolved
+    if (Character.isLowerCase(selector.toString().charAt(0))) {
+      return Superclass.resolved(new Import(selector, false));
+    }
+
     return Superclass.unresolved(selector);
   }
 


### PR DESCRIPTION
* Fixed a bug where a fully qualified extends clause would lead to spurious imports

It is possible that an extends clause (i.e. what is to the right of the `extends` keyword) is a fully qualified name and not just a class name. In this case, we don't want to import anything... but we have no certain way of telling that. Heuristically, we consider that the clause is fully qualified if it starts with a lower case letter (as it is the practice in java to have class names start with an upper case and package name with a lower case).