### PR TITLE
Fix a race condition in MavenString

### DIFF
--- a/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenString.java
+++ b/core/src/main/java/com/nikodoko/javaimports/environment/maven/MavenString.java
@@ -11,7 +11,7 @@ public class MavenString {
   private static final Pattern MAVEN_PROPERTY_PATTERN =
       Pattern.compile("\\$\\{(?<property>[^{}]+)\\}");
   private String template;
-  private Set<String> propertyReferences = new HashSet<>();
+  private volatile Set<String> propertyReferences = new HashSet<>();
 
   public MavenString(String template) {
     this.template = template;
@@ -36,7 +36,7 @@ public class MavenString {
     return props;
   }
 
-  public void substitute(Properties props) {
+  public synchronized void substitute(Properties props) {
     var shouldContinue = false;
     do {
       shouldContinue = substituteOnce(props);

--- a/core/src/main/java/com/nikodoko/javaimports/parser/internal/Scope.java
+++ b/core/src/main/java/com/nikodoko/javaimports/parser/internal/Scope.java
@@ -3,6 +3,7 @@ package com.nikodoko.javaimports.parser.internal;
 import com.nikodoko.javaimports.common.ClassDeclaration;
 import com.nikodoko.javaimports.common.Identifier;
 import com.nikodoko.javaimports.common.Utils;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -69,8 +70,22 @@ public class Scope {
    */
   public String toString() {
     return Utils.toStringHelper(this)
-        .add("identifiers", identifiers)
+        .add("declarations", declarations)
+        .add("unresolved", unresolved)
         .add("maybeClass", maybeClass)
         .toString();
+  }
+
+  public static void debugPrintScopeTree(Scope scope, PrintStream ps) {
+    debugPrintScopeTreeLevel(0, scope, ps);
+  }
+
+  private static void debugPrintScopeTreeLevel(int level, Scope scope, PrintStream ps) {
+    var prefix = " ".repeat(2 * level);
+    ps.print(prefix);
+    ps.println(scope);
+    for (var cs : scope.childScopes) {
+      debugPrintScopeTreeLevel(level + 1, cs, ps);
+    }
   }
 }


### PR DESCRIPTION
* Fixed a bug which could lead to dependencies not being correctly parsed and wrong imports being added

The MavenString class is used in a concurrent setting (`LocalMavenRepository` has a `parallelStream`) and so should be thread safe.